### PR TITLE
Use VAULT_SECRET_ID as default

### DIFF
--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -26,7 +26,7 @@ vault_auth() {
    # approle authentication
   if [ "${BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_METHOD:-}" = "approle" ]; then
     
-    secret_var="${BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_SECRET_ENV:-$VAULT_SECRET_ID}"
+    secret_var="${BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_SECRET_ENV:-VAULT_SECRET_ID}"
 
     if [[ -z "${!secret_var:-}" ]]; then
       echo "+++  🚨 No vault secret id found in \$${secret_var}"


### PR DESCRIPTION
Fix a bug in which it uses the value of that environment variable instead of the actual name of the variable