### PR TITLE
fix secret download

### DIFF
--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -91,7 +91,7 @@ secret_exists() {
 secret_download() {
   local server="$1"
   local key="$2"
-  if ! _secret=$(vault kv get -field=data -format=yaml secret/buildkite/env | sed 's/: /=/g' ); then
+  if ! _secret=$(vault kv get -address="$server" -field=data -format=yaml "$key" | sed 's/: /=/g' ); then
     echo "Failed to download secrets"
     exit 1
   fi


### PR DESCRIPTION
This will make sure that if a user provides a custom secret path we use that path instead of the hardcoded `secret/buildkite/env` value