### PR TITLE
Implement AWS authentication method

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,46 @@ Different types of secrets are supported and exposed to your builds in appropria
 - Environment Variables for strings
 - `git-credential` via git's credential.helper
 
-The plugin supports both [approle](https://developer.hashicorp.com/vault/docs/auth/approle) and [aws](https://developer.hashicorp.com/vault/docs/auth/aws#authentication) Vault auth methods.
+The plugin supports both [approle](https://developer.hashicorp.com/vault/docs/auth/approle) and [aws](https://developer.hashicorp.com/vault/docs/auth/aws) Vault auth methods.
 
-## ENV example (approle authentication)
+## Plugin configuration options
+<table>
+<thead>
+  <tr>
+    <th>Option</th>
+    <th>Description</th>
+    <th>Required</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td><pre>server</pre></td>
+    <td>The URL of the Vault server you wish to use</td>
+    <td>✅</td>
+  </tr>
+  <tr></tr>
+  <tr>
+    <td><pre>auth:<br>&nbsp;method:</pre></td>
+    <td>The type of auth method to use, either <code>approle</code> or <code>aws</code></td>
+    <td>✅</td>
+  </tr>
+  <tr></tr>
+  <tr>
+    <td><pre>auth:<br>&nbsp;role-id:</pre></td>
+    <td>If using the <code>approle</code> method, the Vault role ID to use</td>
+    <td>When using <code>approle</code> auth</td>
+  </tr>
+  <tr></tr>
+  <tr>
+    <td><pre>auth:<br>&nbsp;aws-role-name:</pre></td>
+    <td>If using the <code>aws</code> method, the Vault role name to use.  Defaults to the IAM role used by the EC2 instance</td>
+    <td>When using <code>aws</code> auth</td>
+  </tr>
+</tbody>
+</table>
+
+
+## ENV example
 
 The following pipeline downloads env secrets stored in `https://my-vault-server/secret/buildkite/{pipeline}/env` and git-credentials from `https://my-vault-server/secret/buildkite/{pipeline}/git-credentials`
 

--- a/README.md
+++ b/README.md
@@ -13,12 +13,15 @@ Different types of secrets are supported and exposed to your builds in appropria
 - Environment Variables for strings
 - `git-credential` via git's credential.helper
 
-## ENV example
+The plugin supports both [approle](https://developer.hashicorp.com/vault/docs/auth/approle) and [aws](https://developer.hashicorp.com/vault/docs/auth/aws#authentication) Vault auth methods.
+
+## ENV example (approle authentication)
 
 The following pipeline downloads env secrets stored in `https://my-vault-server/secret/buildkite/{pipeline}/env` and git-credentials from `https://my-vault-server/secret/buildkite/{pipeline}/git-credentials`
 
 The keys in the `env` secret are exposed in the `checkout` and `command` as environment variables. The git-credentials are exposed as an environment variable `GIT_CONFIG_PARAMETERS` and are also exposed in the `checkout` and `command`.
 
+Approle authentication:
 ```yml
 steps:
   - command: ./run_build.sh
@@ -32,6 +35,18 @@ steps:
             secret-env: "VAULT_SECRET_ID"
 ```
 
+AWS authentication:
+```yml
+steps:
+  - command: ./run_build.sh
+    plugins:
+      - vault-secrets#v0.2.0:
+          server: "https://my-vault-server"
+          path: secret/buildkite
+          auth:
+            method: aws
+            aws-role-name: "my-role-name"
+```
 
 ## Uploading Secrets
 

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -64,7 +64,7 @@ vault_auth() {
     
     # export the vault token to be used for this job - this is a standard vault auth command 
     # on success, vault will return the token which we export as VAULT_TOKEN for this shell
-    if ! VAULT_TOKEN=$(vault login -method=aws role="$aws_role_name" -address="$server"); then
+    if ! VAULT_TOKEN=$(vault login -address="$server" -method=aws role="$aws_role_name"); then
       echo "Failed to get vault token"
     fi
 

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -48,7 +48,7 @@ vault_auth() {
     return "${PIPESTATUS[0]}"
   fi
 
-  # aws authenticatino 
+  # aws authentication
   if [ "${BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_METHOD:-}" = "aws" ]; then
     
     # get the name of the IAM role the EC2 instance is using, if any 

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -64,7 +64,7 @@ vault_auth() {
     
     # export the vault token to be used for this job - this is a standard vault auth command 
     # on success, vault will return the token which we export as VAULT_TOKEN for this shell
-    if ! VAULT_TOKEN=$(vault login -address="$server" -method=aws role="$aws_role_name"); then
+    if ! VAULT_TOKEN=$(vault login -field=token -address="$server" -method=aws role="$aws_role_name"); then
       echo "Failed to get vault token"
     fi
 

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -57,7 +57,7 @@ vault_auth() {
     # set the role name to use; either from the plugin configuration, or fall back to the EC2 instance role
     aws_role_name="${BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_AWS_ROLE_NAME:-$EC2_INSTANCE_IAM_ROLE}"
 
-    if [[ -z "${!aws_role_name:-}" ]]; then
+    if [[ -z "${aws_role_name:-}" ]]; then
       echo "+++  🚨 No EC2 instance IAM role found in \$${aws_role_name}"
       exit 1
     fi

--- a/plugin.yml
+++ b/plugin.yml
@@ -16,8 +16,11 @@ configuration:
         method:
           enum:
             - 'approle'
+            - 'aws'
             - ''
         role-id:
+          type: string
+        aws-role-name:
           type: string
   required:
     - server
@@ -25,4 +28,3 @@ configuration:
   additionalProperties: false
   dependencies:
     auth: [ method ]
-

--- a/plugin.yml
+++ b/plugin.yml
@@ -28,3 +28,4 @@ configuration:
   additionalProperties: false
   dependencies:
     auth: [ method ]
+


### PR DESCRIPTION
- Adds support for the [AWS auth method](https://developer.hashicorp.com/vault/docs/auth/aws) in Vault
- This method will look for a parameter `aws-role-name` from the plugin configuration; if undefined, it will try to use the name of the IAM role attached to the EC2 instance (only if running on EC2)
- Updates README with table of configuration options and example of using aws auth method

<img width="715" alt="Screenshot 2022-12-22 at 14 32 26" src="https://user-images.githubusercontent.com/62928797/209157650-170c4de4-d64f-4b7a-9312-56beea6759e8.png">

> _The "unable to list secrets" is due to there being no secret with the pipeline-slug in its name, not because of anything functional._

Approle authentication wasn't suitable for our particular use case so I've implemented the AWS auth method here.  This works as expected on our end; there's no functional change to how secrets are retrieved, only the initial authentication method.  I also took a swing at the README to try and make it a bit more readable.

If/when another authentication method is added we might want to change to a `case` for the method check, but for 2 methods I think this is okay for now.
