### PR TITLE
Fix errors evaluating secrets with special characters

### DIFF
--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -92,7 +92,8 @@ secret_exists() {
 secret_download() {
   local server="$1"
   local key="$2"
-  if ! _secret=$(vault kv get -address="$server" -field=data -format=yaml "$key" | sed 's/: /=/g' ); then
+  if ! _secret=$(vault kv get -address="$server" -field=data -format=yaml "$key" | sed -r 's/: /=/g; s/\"/\\"/g; s/\$/\\$/g; s/=(.*)$/=\"\1\"/g' ); then
+  # if ! _secret=$(vault kv get -address="$server" -field=data -format=yaml "$key" | sed 's/: /=/g' ); then
     echo "Failed to download secrets"
     exit 1
   fi

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -93,7 +93,6 @@ secret_download() {
   local server="$1"
   local key="$2"
   if ! _secret=$(vault kv get -address="$server" -field=data -format=yaml "$key" | sed -r 's/: /=/g; s/\"/\\"/g; s/\$/\\$/g; s/=(.*)$/=\"\1\"/g' ); then
-  # if ! _secret=$(vault kv get -address="$server" -field=data -format=yaml "$key" | sed 's/: /=/g' ); then
     echo "Failed to download secrets"
     exit 1
   fi

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -92,7 +92,7 @@ secret_exists() {
 secret_download() {
   local server="$1"
   local key="$2"
-  if ! _secret=$(vault kv get -address="$server" -field=data -format=yaml "$key" | sed -r 's/: /=/g; s/\"/\\"/g; s/\$/\\$/g; s/=(.*)$/=\"\1\"/g' ); then
+  if ! _secret=$(vault kv get -address="$server" -field=data -format=yaml "$key" | sed -r 's/: /=/g; s/\/\\/g; s/=(.*)$/=\"\1\"/g' ); then
     echo "Failed to download secrets"
     exit 1
   fi

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -92,7 +92,7 @@ secret_exists() {
 secret_download() {
   local server="$1"
   local key="$2"
-  if ! _secret=$(vault kv get -address="$server" -field=data -format=yaml "$key" | sed -r 's/: /=/g; s/\/\\/g; s/=(.*)$/=\"\1\"/g' ); then
+  if ! _secret=$(vault kv get -address="$server" -field=data -format=yaml "$key" | sed -r 's/: /=/; s/\"/\\"/g; s/\$/\\$/g; s/=(.*)$/=\"\1\"/g' ); then
     echo "Failed to download secrets"
     exit 1
   fi

--- a/tests/environment-hook.bats
+++ b/tests/environment-hook.bats
@@ -32,7 +32,7 @@ load '/usr/local/lib/bats/load.bash'
 @test "Load default env file containing secrets with special characters from vault server" {
   export BUILDKITE_PLUGIN_VAULT_SECRETS_SERVER=https://vault_svr_url
   export BUILDKITE_PLUGIN_VAULT_SECRETS_DUMP_ENV=true
-  export TESTDATA="MY_SECRET=\"|- fooblah\""
+  export TESTDATA="MY_SECRET=\"|- :fooblah\""
   export BUILDKITE_PIPELINE_SLUG=testpipe
 
   stub vault \
@@ -43,7 +43,7 @@ load '/usr/local/lib/bats/load.bash'
   run bash -c "$PWD/hooks/environment && $PWD/hooks/pre-exit"
 
   assert_success
-  assert_output --partial "MY_SECRET=|- fooblah"
+  assert_output --partial "MY_SECRET=|- :fooblah"
   refute_output --partial "ANOTHER_SECRET=baa"
 
   unstub vault
@@ -561,3 +561,4 @@ load '/usr/local/lib/bats/load.bash'
   unset BUILDKITE_PIPELINE_SLUG
   unset BUILDKITE_PLUGIN_VAULT_SECRETS_PATH
 }
+

--- a/tests/environment-hook.bats
+++ b/tests/environment-hook.bats
@@ -29,6 +29,26 @@ load '/usr/local/lib/bats/load.bash'
   unstub vault
 }
 
+@test "Load default env file containing secrets with special characters from vault server" {
+  export BUILDKITE_PLUGIN_VAULT_SECRETS_SERVER=https://vault_svr_url
+  export BUILDKITE_PLUGIN_VAULT_SECRETS_DUMP_ENV=true
+  export TESTDATA="MY_SECRET=\"|- fooblah\""
+  export BUILDKITE_PIPELINE_SLUG=testpipe
+
+  stub vault \
+    "kv list -address=https://vault_svr_url -format=yaml data/buildkite/testpipe : exit 0" \
+    "kv list -address=https://vault_svr_url -format=yaml data/buildkite : echo 'env'" \
+    "kv get -address=https://vault_svr_url -field=data -format=yaml data/buildkite/env : echo ${TESTDATA}"
+
+  run bash -c "$PWD/hooks/environment && $PWD/hooks/pre-exit"
+
+  assert_success
+  assert_output --partial "MY_SECRET=|- fooblah"
+  refute_output --partial "ANOTHER_SECRET=baa"
+
+  unstub vault
+}
+
 @test "Load default environment file from vault server" {
   export BUILDKITE_PLUGIN_VAULT_SECRETS_SERVER=https://vault_svr_url
   export BUILDKITE_PLUGIN_VAULT_SECRETS_DUMP_ENV=true

--- a/tests/environment-hook.bats
+++ b/tests/environment-hook.bats
@@ -32,7 +32,7 @@ load '/usr/local/lib/bats/load.bash'
 @test "Load default env file containing secrets with special characters from vault server" {
   export BUILDKITE_PLUGIN_VAULT_SECRETS_SERVER=https://vault_svr_url
   export BUILDKITE_PLUGIN_VAULT_SECRETS_DUMP_ENV=true
-  export TESTDATA="MY_SECRET=\"|- :fooblah\""
+  export TESTDATA="MY_SECRET=\"|- : fooblah\""
   export BUILDKITE_PIPELINE_SLUG=testpipe
 
   stub vault \


### PR DESCRIPTION
This addresses an issue with special characters in #16, by adding some `sed` magic to the secret_download function (thank you @fd-jonathanlinn!)

Includes a test case to cover this pattern.

In the future, it might make sense to move to `json` output instead of YAML, but for now, this should work to cover most use cases.