### PR TITLE
Enable support for Vault Namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,9 @@ Alternative Base Path to use for Vault secrets. This is expected to be a [KV Sto
 
 Defaults to: `data/buildkite`
 
+### `namespace` (optional, string)
+Configure the [Enterprise Namespace](https://developer.hashicorp.com/vault/docs/enterprise/namespaces) to be used when querying the vault server
+
 
 ### `auth` (required, object)
 Dictionary/map with the configuration of the parameters the plugin should use to authenticate with Vault.

--- a/hooks/environment
+++ b/hooks/environment
@@ -71,6 +71,10 @@ basedir="$( cd "$( dirname "${_source}" )" && cd .. && pwd )"
 TMPDIR=${TMPDIR:-/tmp}
 VAULT_BASE_PATH="${BUILDKITE_PLUGIN_VAULT_SECRETS_PATH:-data/buildkite}"
 
+# Check to see if we are using a different namespace for cloud/enterprise, otherwise use the default
+export VAULT_NAMESPACE="${BUILDKITE_PLUGIN_VAULT_SECRETS_NAMESPACE:-admin}"
+echo "Using namespace: $VAULT_NAMESPACE"
+
 vault_server="${BUILDKITE_PLUGIN_VAULT_SECRETS_SERVER:-}"
 vault_path="${VAULT_BASE_PATH:-}"
 [ -n "${BUILDKITE_PLUGIN_VAULT_SECRETS_PREFIX:-}" ] && vault_path="${vault_path}/${BUILDKITE_PLUGIN_VAULT_SECRETS_PREFIX}"

--- a/plugin.yml
+++ b/plugin.yml
@@ -12,6 +12,8 @@ configuration:
       type: string
     server:
       type: string
+    namespace:
+      type: string
     auth:
       type: object
       properties:


### PR DESCRIPTION
This will allow us to support [Vault Namespaces](https://developer.hashicorp.com/vault/docs/enterprise/namespaces) directly in the plugin config. While it is a value that can be set outside the plugin, passing the value of the namespace in the config will update `VAULT_NAMESPACE` during the environment hook execution and ensure that all queries to Vault are done using the configured namespace.