### PR TITLE
Tester and cleanup

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -20,8 +20,7 @@ steps:
 
   - label: ":test_tube: Tests"
     plugins:
-      - docker-compose#v4.11.0:
-          run: tests
+      - tester#v1.0.0: ~
           
   - label: ":vault: :test_tube: Integration Tests"
     command: .buildkite/steps/test_envvar.sh

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,6 +11,7 @@ steps:
             - examples/*
             - .buildkite/*.sh
             - .buildkite/steps/*.sh
+            - git-credential-vault-secrets
 
   - label: "Linter"
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,6 +8,9 @@ steps:
           files: 
             - lib/*.bash
             - hooks/*
+            - examples/*
+            - .buildkite/*.sh
+            - .buildkite/steps/*.sh
 
   - label: "Linter"
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -20,7 +20,7 @@ steps:
 
   - label: ":test_tube: Tests"
     plugins:
-      - tester#v1.0.0: ~
+      - plugin-tester#v1.0.0: ~
           
   - label: ":vault: :test_tube: Integration Tests"
     command: .buildkite/steps/test_envvar.sh

--- a/.buildkite/test_credentials.sh
+++ b/.buildkite/test_credentials.sh
@@ -1,7 +1,7 @@
-#!/bin/ash
+#!/bin/sh
 set -eu
 
-if [[ -d example-private-repository ]] ; then
+if [ -d example-private-repository ] ; then
   rm -rf example-private-repository
 fi
 

--- a/examples/update-env-secret
+++ b/examples/update-env-secret
@@ -74,4 +74,4 @@ if [ -n "${value:-}" ] ; then
 else
   _val=$(getVarValue)
 fi
-echo -n "$(echo "${var}='${_val}'" | base64)" | vault write "${BASE_PATH}${PIPELINE}/env/${var}" value=-
+vault write "${BASE_PATH}${PIPELINE}/env/${var}" value="${var}='${_val}'"

--- a/examples/update-env-secret
+++ b/examples/update-env-secret
@@ -25,18 +25,17 @@ getVarValue() {
   if (( $# == 0 )) ; then
     input=$(cat < /dev/stdin)
   else
-    input="$@"
+    input="$*"
   fi
 
   echo "${input}"
 }
 
-set -o noclobber -o nounset -o pipefail
-[ $? -eq 0 ] || {
-    echo "Incorrect options provided"
-    show_help
-    exit 1
-}
+if ! set -o noclobber -o nounset -o pipefail; then
+  echo "Incorrect options provided"
+  show_help
+  exit 1
+fi
 
 BASE_PATH="kv/buildkite"
 if [ -z "${VAULT_ADDR:-}" ] ; then
@@ -46,8 +45,8 @@ fi
 
 while [ "${@+defined}" ]; do
     case "$1" in
-        --help) help=1 ;;
-        --debug) set -o xtrace ; debug=1 ;;
+        --help) help ;;
+        --debug) set -o xtrace ;;
         --pipeline) shift ; PIPELINE="/${1}" ;;
         --basepath) shift ; BASE_PATH="${1}" ;;
         --var) shift ; var="${1}" ;;
@@ -70,9 +69,9 @@ fi
 vault token-lookup > /dev/null 2>&1
 
 authenticate
-if [ ! -z "${value:-}" ] ; then
+if [ -n "${value:-}" ] ; then
   _val=$(getVarValue "${value:-}")
 else
   _val=$(getVarValue)
 fi
-echo -n $(echo ${var}=\'${_val}\' | base64) | vault write ${BASE_PATH}${PIPELINE}/env/${var} value=-
+echo -n "$(echo "${var}='${_val}'" | base64)" | vault write "${BASE_PATH}${PIPELINE}/env/${var}" value=-

--- a/examples/update-sshkey-secret
+++ b/examples/update-sshkey-secret
@@ -19,17 +19,11 @@ help() {
   "
 }
 
-set -o noclobber -o nounset -o pipefail
-[ $? -eq 0 ] || {
-    echo "Incorrect options provided"
-    show_help
-    exit 1
-}
-
-BASE64_DECODE_ARGS="-d"
-case `uname -s` in
-  Darwin) BASE64_DECODE_ARGS="--decode" ;;
-esac
+if ! set -o noclobber -o nounset -o pipefail; then
+  echo "Incorrect options provided"
+  show_help
+  exit 1
+fi
 
 BASE_PATH="kv/buildkite"
 if [ -z "${VAULT_ADDR:-}" ] ; then
@@ -39,8 +33,8 @@ fi
 
 while [ "${@+defined}" ]; do
     case "$1" in
-        --help) help=1 ;;
-        --debug) set -o xtrace ; debug=1 ;;
+        --help) help ;;
+        --debug) set -o xtrace ;;
         --pipeline) shift ; PIPELINE="/${1}" ;;
         --basepath) shift ; BASE_PATH="${1}" ;;
         --) shift ; break ;;
@@ -61,15 +55,14 @@ fi
 vault token-lookup > /dev/null 2>&1
 authenticate
 TMPDIR=$(mktemp -d -u)
-mkdir -p $TMPDIR
-cd $TMPDIR
+mkdir -p "$TMPDIR"
 
-ssh-keygen -f ./private_ssh_key -N ''
-if [ $? -eq 0 ] ; then
-  echo -n $(cat private_ssh_key | base64) | vault write ${BASE_PATH}${PIPELINE}/private_ssh_key \
-    value=-
-  echo -n $(cat private_ssh_key.pub | base64) | vault write ${BASE_PATH}${PIPELINE}/private_ssh_key.pub \
-    value=-
+if ssh-keygen -f "$TMPDIR"/private_ssh_key -N ''; then
+  base64 "${TMPDIR}/private_ssh_key" \
+  | vault write "${BASE_PATH}${PIPELINE}/private_ssh_key" value=-
+
+  base64 "${TMPDIR}/private_ssh_key.pub" \
+  | vault write "${BASE_PATH}${PIPELINE}/private_ssh_key.pub" value=-
 fi
 
-rm -rf $TMPDIR
+rm -rf "${TMPDIR}"

--- a/examples/update-sshkey-secret
+++ b/examples/update-sshkey-secret
@@ -58,10 +58,10 @@ TMPDIR=$(mktemp -d -u)
 mkdir -p "$TMPDIR"
 
 if ssh-keygen -f "$TMPDIR"/private_ssh_key -N ''; then
-  base64 "${TMPDIR}/private_ssh_key" \
+  cat "${TMPDIR}/private_ssh_key" \
   | vault write "${BASE_PATH}${PIPELINE}/private_ssh_key" value=-
 
-  base64 "${TMPDIR}/private_ssh_key.pub" \
+  cat "${TMPDIR}/private_ssh_key.pub" \
   | vault write "${BASE_PATH}${PIPELINE}/private_ssh_key.pub" value=-
 fi
 

--- a/git-credential-vault-secrets
+++ b/git-credential-vault-secrets
@@ -29,7 +29,7 @@ parse_url() {
   export uri_user=${BASH_REMATCH[5]}
   export uri_password=${BASH_REMATCH[7]}
   export uri_host=${BASH_REMATCH[8]}
-  export uri_port=${BASH_REMATCH[10]}
+  export uri_port=${BASH_REMATCH[9]}
   export uri_path=${BASH_REMATCH[11]}
   export uri_query=${BASH_REMATCH[12]}
   export uri_fragment=${BASH_REMATCH[13]}
@@ -41,7 +41,7 @@ parse_url() {
   while [[ $path =~ $pattern ]]; do
     eval "uri_parts[$count]=\"${BASH_REMATCH[1]}\""
     path="${path:${#BASH_REMATCH[0]}}"
-    let count++
+    ((count++))
   done
 
   # query parsing
@@ -52,8 +52,11 @@ parse_url() {
     eval "uri_args[$count]=\"${BASH_REMATCH[1]}\""
     eval "uri_arg_${BASH_REMATCH[1]}=\"${BASH_REMATCH[3]}\""
     query="${query:${#BASH_REMATCH[0]}}"
-    let count++
+    ((count++))
   done
+
+  # query was parsed correctly
+  return 0
 }
 
 vault_svr="$1"
@@ -72,7 +75,7 @@ if [ "$action" == "get" ] ; then
 
     # https://git-scm.com/docs/git-credential#IOFMT
     echo "protocol=${uri_schema}"
-    echo "host=${uri_host}"
+    echo "host=${uri_host}${uri_port}"
     echo "username=${uri_user}"
     echo "password=${uri_password}"
   done

--- a/git-credential-vault-secrets
+++ b/git-credential-vault-secrets
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -eu
-set -o xtrace
+# set -o xtrace
 
 basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 . "$basedir/lib/shared.bash"

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -94,10 +94,6 @@ secret_download() {
     echo "Failed to download secrets"
     exit 1
   fi
-  # shellcheck disable=SC2181
-  if [ "$?" -ne 0 ] ; then
-    return 1
-  fi
   echo "$_secret"
 }
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:base",
+    ":disableDependencyDashboard"
   ]
 }

--- a/tests/auth-tests.bats
+++ b/tests/auth-tests.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-load '/usr/local/lib/bats/load.bash'
+load "${BATS_PLUGIN_PATH}/load.bash"
 
 # export SSH_AGENT_STUB_DEBUG=/dev/tty
 # export SSH_ADD_STUB_DEBUG=/dev/tty
@@ -48,12 +48,6 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial 'Successfully authenticated. You are now logged in'
 
   unstub vault
-
-  unset BUILDKITE_PLUGIN_VAULT_SECRETS_PATH
-  unset BUILDKITE_PLUGIN_VAULT_SECRETS_SERVER
-  unset BUILDKITE_PLUGIN_VAULT_SECRETS_DUMP_ENV
-  unset BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_TOKEN
-  unset BUILDKITE_PIPELINE_SLUG
 }
 
 @test "test aws auth method" {
@@ -75,10 +69,4 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial 'Successfully authenticated. You are now logged in'
 
   unstub vault
-
-  unset BUILDKITE_PLUGIN_VAULT_SECRETS_PATH
-  unset BUILDKITE_PLUGIN_VAULT_SECRETS_SERVER
-  unset BUILDKITE_PLUGIN_VAULT_SECRETS_DUMP_ENV
-  unset BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_METHOD
-  unset BUILDKITE_PIPELINE_SLUG
 }

--- a/tests/environment-hook.bats
+++ b/tests/environment-hook.bats
@@ -17,7 +17,7 @@ setup() {
 #-------
 # Default scope
 @test "Load default env file from vault server" {
-  export TESTDATA='MY_SECRET=fooblah'
+  export TESTDATA='MY_SECRET: fooblah'
 
   stub vault \
     "kv list -address=https://vault_svr_url -format=yaml data/buildkite/testpipe : exit 0" \
@@ -34,7 +34,7 @@ setup() {
 }
 
 @test "Load default env file containing secrets with special characters from vault server" {
-  export TESTDATA="MY_SECRET=\"|- $:fooblah\""
+  export TESTDATA="MY_SECRET: \"|- $:fooblah\""
 
   stub vault \
     "kv list -address=https://vault_svr_url -format=yaml data/buildkite/testpipe : exit 0" \
@@ -51,7 +51,7 @@ setup() {
 }
 
 @test "Load default env file and convert secrets with \": \" pattern from vault server" {
-  export TESTDATA="MY_SECRET=\"Likes: llamas\""
+  export TESTDATA="MY_SECRET: \"Likes: llamas\""
 
   stub vault \
     "kv list -address=https://vault_svr_url -format=yaml data/buildkite/testpipe : exit 0" \
@@ -61,14 +61,14 @@ setup() {
   run bash -c "$PWD/hooks/environment && $PWD/hooks/pre-exit"
 
   assert_success
-  assert_output --partial "MY_SECRET=Likes=llamas"
+  assert_output --partial "MY_SECRET=Likes: llamas"
   refute_output --partial "ANOTHER_SECRET=baa"
 
   unstub vault
 }
 
 @test "Load default environment file from vault server" {
-  export TESTDATA='MY_SECRET=fooblah'
+  export TESTDATA='MY_SECRET: fooblah'
 
   stub vault \
     "kv list -address=https://vault_svr_url -format=yaml data/buildkite/testpipe : exit 0" \
@@ -85,8 +85,8 @@ setup() {
 }
 
 @test "Load default env and environments files from vault server" {
-  export TESTDATA_ENV1='MY_SECRET=fooblah'
-  export TESTDATA_ENV2='ANOTHER_SECRET=baa'
+  export TESTDATA_ENV1='MY_SECRET: fooblah'
+  export TESTDATA_ENV2='ANOTHER_SECRET: baa'
 
   stub vault \
     "kv list -address=https://vault_svr_url -format=yaml data/buildkite/testpipe : exit 0" \
@@ -106,7 +106,7 @@ setup() {
 #-------
 # Project scope
 @test "Load project env file from vault server" {
-  export TESTDATA='MY_SECRET=fooblah'
+  export TESTDATA='MY_SECRET: fooblah'
 
   stub vault \
     "kv list -address=https://vault_svr_url -format=yaml data/buildkite/testpipe : echo 'env'" \
@@ -123,7 +123,7 @@ setup() {
 }
 
 @test "Load project environment file from vault server" {
-  export TESTDATA='echo MY_SECRET=fooblah'
+  export TESTDATA='MY_SECRET: fooblah'
 
   stub vault \
     "kv list -address=https://vault_svr_url -format=yaml data/buildkite/testpipe : echo 'environment'" \
@@ -140,8 +140,8 @@ setup() {
 }
 
 @test "Load project env and environments files from vault server" {
-  export TESTDATA_ENV1='echo MY_SECRET=fooblah'
-  export TESTDATA_ENV2='echo ANOTHER_SECRET=baa'
+  export TESTDATA_ENV1='MY_SECRET: fooblah'
+  export TESTDATA_ENV2='ANOTHER_SECRET: baa'
 
   stub vault \
     "kv list -address=https://vault_svr_url -format=yaml data/buildkite/testpipe : echo 'env environment'" \
@@ -161,8 +161,8 @@ setup() {
 #-------
 # Combinations of scopes
 @test "Load default and project env files from vault server" {
-  export TESTDATA_ENV1='echo MY_SECRET=fooblah'
-  export TESTDATA_ENV2='echo ANOTHER_SECRET=baa'
+  export TESTDATA_ENV1='MY_SECRET: fooblah'
+  export TESTDATA_ENV2='ANOTHER_SECRET: baa'
 
   stub vault \
     "kv list -address=https://vault_svr_url -format=yaml data/buildkite/testpipe : echo 'env'" \
@@ -180,8 +180,8 @@ setup() {
 }
 
 @test "Load default and project environment files from vault server" {
-  export TESTDATA_ENV1='echo MY_SECRET=fooblah'
-  export TESTDATA_ENV2='echo ANOTHER_SECRET=baa'
+  export TESTDATA_ENV1='MY_SECRET: fooblah'
+  export TESTDATA_ENV2='ANOTHER_SECRET: baa'
 
   stub vault \
     "kv list -address=https://vault_svr_url -format=yaml data/buildkite/testpipe : echo 'environment'" \
@@ -201,10 +201,10 @@ setup() {
 #-------
 # All scopes and env, environment files
 @test "Load env and environments files for project and default from vault server" {
-  export TESTDATA_ENV1='echo MY_SECRET1=baa1'
-  export TESTDATA_ENV2='echo MY_SECRET2=baa2'
-  export TESTDATA_ENV3='echo MY_SECRET3=baa3'
-  export TESTDATA_ENV4='echo MY_SECRET4=baa4'
+  export TESTDATA_ENV1='MY_SECRET1: baa1'
+  export TESTDATA_ENV2='MY_SECRET2: baa2'
+  export TESTDATA_ENV3='MY_SECRET3: baa3'
+  export TESTDATA_ENV4='MY_SECRET4: baa4'
 
   stub vault \
     "kv list -address=https://vault_svr_url -format=yaml data/buildkite/testpipe : echo 'env environment'" \
@@ -242,7 +242,7 @@ setup() {
 }
 
 @test "Load pipeline git-credentials from vault into GIT_CONFIG_PARAMETERS" {
-  export TESTDATA_ENV1='MY_SECRET1=baa1'
+  export TESTDATA_ENV1='MY_SECRET1: baa1'
 
   stub vault \
     "kv list -address=https://vault_svr_url -format=yaml data/buildkite/testpipe : echo -e '- git-credentials'" \
@@ -264,7 +264,7 @@ setup() {
 #-------
 # ssh-keys
 @test "Load default ssh-key from vault into ssh-agent" {
-  export TESTDATA='echo foobar'
+  export TESTDATA='foobar'
 
   stub ssh-agent "-s : echo export SSH_AGENT_PID=26345"
 
@@ -288,7 +288,7 @@ setup() {
 }
 
 @test "Load project ssh-key from vault into ssh-agent" {
-  export TESTDATA='echo foobar'
+  export TESTDATA='foobar'
 
   stub ssh-agent "-s : echo export SSH_AGENT_PID=26345"
 
@@ -312,8 +312,8 @@ setup() {
 }
 
 @test "Load default and project ssh-keys from vault into ssh-agent" {
-  export TESTDATA='echo foobar'
-  export TESTDATA2='echo foobar2'
+  export TESTDATA='foobar'
+  export TESTDATA2='foobar2'
 
   stub ssh-agent "-s : echo export SSH_AGENT_PID=26345"
 
@@ -339,8 +339,8 @@ setup() {
 }
 
 @test "Load default ssh-key and env from vault" {
-  export TESTDATA_KEY='echo foobar'
-  export TESTDATA_ENV='MY_SECRET=fooblah'
+  export TESTDATA_KEY='foobar'
+  export TESTDATA_ENV='MY_SECRET: fooblah'
 
   stub ssh-agent "-s : echo export SSH_AGENT_PID=54252"
 
@@ -366,8 +366,8 @@ setup() {
 }
 
 @test "Load project ssh-key and env from vault" {
-  export TESTDATA_KEY='echo foobar'
-  export TESTDATA_ENV='MY_SECRET=fooblah'
+  export TESTDATA_KEY='foobar'
+  export TESTDATA_ENV='MY_SECRET: fooblah'
 
   stub ssh-agent "-s : echo export SSH_AGENT_PID=12423"
 
@@ -393,8 +393,8 @@ setup() {
 }
 
 @test "Load default ssh-key, env and git-credentials from vault into ssh-agent" {
-  export TESTDATA_KEY='echo foobar'
-  export TESTDATA_ENV='MY_SECRET=fooblah'
+  export TESTDATA_KEY='foobar'
+  export TESTDATA_ENV='MY_SECRET: fooblah'
   export TESTDATA_GIT='me@pass'
 
   stub ssh-agent "-s : echo export SSH_AGENT_PID=24124"
@@ -424,8 +424,8 @@ setup() {
 }
 
 @test "Load project ssh-key, env and git-credentials from vault into ssh-agent" {
-  export TESTDATA_KEY='echo foobar'
-  export TESTDATA_ENV='MY_SECRET=fooblah'
+  export TESTDATA_KEY='foobar'
+  export TESTDATA_ENV='MY_SECRET: fooblah'
   export TESTDATA_GIT='me@pass'
 
   stub ssh-agent "-s : echo export SSH_AGENT_PID=12423"
@@ -454,13 +454,13 @@ setup() {
 }
 
 @test "Dump env secrets" {
-  export TESTDATA_ENV_1='TEST_SECRET=foobar'
-  export TESTDATA_ENV_2='ANOTHER_SECRET=foo'
+  export TESTDATA_ENV_1='TEST_SECRET: foobar'
+  export TESTDATA_ENV_2='ANOTHER_SECRET: foo'
 
   stub vault \
     "kv list -address=https://vault_svr_url -format=yaml data/buildkite/testpipe : echo -e 'env'" \
     "kv list -address=https://vault_svr_url -format=yaml data/buildkite : exit 0" \
-    "kv get -address=https://vault_svr_url -field=data -format=yaml data/buildkite/testpipe/env : echo '${TESTDATA_ENV_1}\n ${TESTDATA_ENV_2}'" \
+    "kv get -address=https://vault_svr_url -field=data -format=yaml data/buildkite/testpipe/env : echo '${TESTDATA_ENV_1}'; echo '${TESTDATA_ENV_2}'" \
 
   run bash -c "$PWD/hooks/environment && $PWD/hooks/pre-exit"
 
@@ -469,12 +469,6 @@ setup() {
   assert_output --partial "ANOTHER_SECRET=foo"
 
   unstub vault
-
-  unset TESTDATA
-  unset BUILDKITE_PLUGIN_VAULT_SECRETS_DUMP_ENV
-  unset BUILDKITE_PLUGIN_VAULT_SECRETS_SERVER
-  unset BUILDKITE_PIPELINE_SLUG
-  unset BUILDKITE_PLUGIN_VAULT_SECRETS_DUMP_ENV
 }
 
 @test "test path option" {
@@ -491,16 +485,11 @@ setup() {
   assert_output --partial "Checking vault secrets foobar"
 
   unstub vault
-
-  unset BUILDKITE_PLUGIN_VAULT_SECRETS_DUMP_ENV
-  unset BUILDKITE_PLUGIN_VAULT_SECRETS_SERVER
-  unset BUILDKITE_PIPELINE_SLUG
-  unset BUILDKITE_PLUGIN_VAULT_SECRETS_PATH
 }
 
 @test "Custom Namespace is set in environment hook" {
   export BUILDKITE_PLUGIN_VAULT_SECRETS_NAMESPACE=llamas
-  export TESTDATA='MY_SECRET=fooblah'
+  export TESTDATA='MY_SECRET: fooblah'
 
   stub vault \
     "kv list -address=https://vault_svr_url -format=yaml data/buildkite/testpipe : exit 0" \

--- a/tests/environment-hook.bats
+++ b/tests/environment-hook.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-load '/usr/local/lib/bats/load.bash'
+load "${BATS_PLUGIN_PATH}/load.bash"
 
 # export SSH_AGENT_STUB_DEBUG=/dev/tty
 # export SSH_ADD_STUB_DEBUG=/dev/tty

--- a/tests/environment-hook.bats
+++ b/tests/environment-hook.bats
@@ -269,7 +269,6 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_VAULT_SECRETS_SERVER=https://vault_svr_url
   export BUILDKITE_PLUGIN_VAULT_SECRETS_DUMP_ENV=true
   export BUILDKITE_PIPELINE_SLUG=testpipe
-  export TESTDATA_ENV1=`echo MY_SECRET1=baa1 | base64`
 
   stub vault \
     "kv list -address=https://vault_svr_url -format=yaml data/buildkite/testpipe : exit 0 " \
@@ -288,7 +287,7 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_VAULT_SECRETS_SERVER=https://vault_svr_url
   export BUILDKITE_PLUGIN_VAULT_SECRETS_DUMP_ENV=true
   export BUILDKITE_PIPELINE_SLUG=testpipe
-  export TESTDATA_ENV1=`echo MY_SECRET1=baa1`
+  export TESTDATA_ENV1='MY_SECRET1=baa1'
 
   stub vault \
     "kv list -address=https://vault_svr_url -format=yaml data/buildkite/testpipe : echo -e '- git-credentials'" \

--- a/tests/environment-hook.bats
+++ b/tests/environment-hook.bats
@@ -1,19 +1,23 @@
 #!/usr/bin/env bats
 
-load "${BATS_PLUGIN_PATH}/load.bash"
-
 # export SSH_AGENT_STUB_DEBUG=/dev/tty
 # export SSH_ADD_STUB_DEBUG=/dev/tty
 # export VAULT_STUB_DEBUG=/dev/tty
 # export GIT_STUB_DEBUG=/dev/tty
 
+setup() {
+  load "${BATS_PLUGIN_PATH}/load.bash"
+
+  export BUILDKITE_PIPELINE_SLUG=testpipe
+
+  export BUILDKITE_PLUGIN_VAULT_SECRETS_SERVER=https://vault_svr_url
+  export BUILDKITE_PLUGIN_VAULT_SECRETS_DUMP_ENV=true
+}
+
 #-------
 # Default scope
 @test "Load default env file from vault server" {
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_SERVER=https://vault_svr_url
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_DUMP_ENV=true
   export TESTDATA='MY_SECRET=fooblah'
-  export BUILDKITE_PIPELINE_SLUG=testpipe
 
   stub vault \
     "kv list -address=https://vault_svr_url -format=yaml data/buildkite/testpipe : exit 0" \
@@ -30,10 +34,7 @@ load "${BATS_PLUGIN_PATH}/load.bash"
 }
 
 @test "Load default env file containing secrets with special characters from vault server" {
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_SERVER=https://vault_svr_url
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_DUMP_ENV=true
   export TESTDATA="MY_SECRET=\"|- $:fooblah\""
-  export BUILDKITE_PIPELINE_SLUG=testpipe
 
   stub vault \
     "kv list -address=https://vault_svr_url -format=yaml data/buildkite/testpipe : exit 0" \
@@ -49,12 +50,8 @@ load "${BATS_PLUGIN_PATH}/load.bash"
   unstub vault
 }
 
-
 @test "Load default env file and convert secrets with \": \" pattern from vault server" {
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_SERVER=https://vault_svr_url
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_DUMP_ENV=true
   export TESTDATA="MY_SECRET=\"Likes: llamas\""
-  export BUILDKITE_PIPELINE_SLUG=testpipe
 
   stub vault \
     "kv list -address=https://vault_svr_url -format=yaml data/buildkite/testpipe : exit 0" \
@@ -70,12 +67,8 @@ load "${BATS_PLUGIN_PATH}/load.bash"
   unstub vault
 }
 
-
 @test "Load default environment file from vault server" {
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_SERVER=https://vault_svr_url
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_DUMP_ENV=true
   export TESTDATA='MY_SECRET=fooblah'
-  export BUILDKITE_PIPELINE_SLUG=testpipe
 
   stub vault \
     "kv list -address=https://vault_svr_url -format=yaml data/buildkite/testpipe : exit 0" \
@@ -92,13 +85,8 @@ load "${BATS_PLUGIN_PATH}/load.bash"
 }
 
 @test "Load default env and environments files from vault server" {
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_SERVER=https://vault_svr_url
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_DUMP_ENV=true
   export TESTDATA_ENV1='MY_SECRET=fooblah'
   export TESTDATA_ENV2='ANOTHER_SECRET=baa'
-  export BUILDKITE_PIPELINE_SLUG=testpipe
-
-
 
   stub vault \
     "kv list -address=https://vault_svr_url -format=yaml data/buildkite/testpipe : exit 0" \
@@ -118,9 +106,6 @@ load "${BATS_PLUGIN_PATH}/load.bash"
 #-------
 # Project scope
 @test "Load project env file from vault server" {
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_SERVER=https://vault_svr_url
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_DUMP_ENV=true
-  export BUILDKITE_PIPELINE_SLUG=testpipe
   export TESTDATA='MY_SECRET=fooblah'
 
   stub vault \
@@ -138,9 +123,6 @@ load "${BATS_PLUGIN_PATH}/load.bash"
 }
 
 @test "Load project environment file from vault server" {
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_SERVER=https://vault_svr_url
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_DUMP_ENV=true
-  export BUILDKITE_PIPELINE_SLUG=testpipe
   export TESTDATA='echo MY_SECRET=fooblah'
 
   stub vault \
@@ -155,14 +137,9 @@ load "${BATS_PLUGIN_PATH}/load.bash"
   refute_output --partial "ANOTHER_SECRET=baa"
 
   unstub vault
-
-
 }
 
 @test "Load project env and environments files from vault server" {
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_SERVER=https://vault_svr_url
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_DUMP_ENV=true
-  export BUILDKITE_PIPELINE_SLUG=testpipe
   export TESTDATA_ENV1='echo MY_SECRET=fooblah'
   export TESTDATA_ENV2='echo ANOTHER_SECRET=baa'
 
@@ -179,15 +156,11 @@ load "${BATS_PLUGIN_PATH}/load.bash"
   assert_output --partial "ANOTHER_SECRET=baa"
 
   unstub vault
-
 }
 
 #-------
 # Combinations of scopes
 @test "Load default and project env files from vault server" {
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_SERVER=https://vault_svr_url
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_DUMP_ENV=true
-  export BUILDKITE_PIPELINE_SLUG=testpipe
   export TESTDATA_ENV1='echo MY_SECRET=fooblah'
   export TESTDATA_ENV2='echo ANOTHER_SECRET=baa'
 
@@ -204,14 +177,9 @@ load "${BATS_PLUGIN_PATH}/load.bash"
   assert_output --partial "ANOTHER_SECRET=baa"
 
   unstub vault
-
-
 }
 
 @test "Load default and project environment files from vault server" {
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_SERVER=https://vault_svr_url
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_DUMP_ENV=true
-  export BUILDKITE_PIPELINE_SLUG=testpipe
   export TESTDATA_ENV1='echo MY_SECRET=fooblah'
   export TESTDATA_ENV2='echo ANOTHER_SECRET=baa'
 
@@ -228,15 +196,11 @@ load "${BATS_PLUGIN_PATH}/load.bash"
   assert_output --partial "ANOTHER_SECRET=baa"
 
   unstub vault
-
 }
 
 #-------
 # All scopes and env, environment files
 @test "Load env and environments files for project and default from vault server" {
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_SERVER=https://vault_svr_url
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_DUMP_ENV=true
-  export BUILDKITE_PIPELINE_SLUG=testpipe
   export TESTDATA_ENV1='echo MY_SECRET1=baa1'
   export TESTDATA_ENV2='echo MY_SECRET2=baa2'
   export TESTDATA_ENV3='echo MY_SECRET3=baa3'
@@ -249,7 +213,6 @@ load "${BATS_PLUGIN_PATH}/load.bash"
     "kv get -address=https://vault_svr_url -field=data -format=yaml data/buildkite/testpipe/environment : echo ${TESTDATA_ENV2}" \
     "kv get -address=https://vault_svr_url -field=data -format=yaml data/buildkite/env : echo ${TESTDATA_ENV3}" \
     "kv get -address=https://vault_svr_url -field=data -format=yaml data/buildkite/environment : echo ${TESTDATA_ENV4}"
-    
 
   run bash -c "$PWD/hooks/environment && $PWD/hooks/pre-exit"
 
@@ -260,16 +223,11 @@ load "${BATS_PLUGIN_PATH}/load.bash"
   assert_output --partial "MY_SECRET4=baa4"
 
   unstub vault
-
 }
 
 #-------
 # Git Credentials
 @test "Load default git-credentials from vault into GIT_CONFIG_PARAMETERS" {
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_SERVER=https://vault_svr_url
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_DUMP_ENV=true
-  export BUILDKITE_PIPELINE_SLUG=testpipe
-
   stub vault \
     "kv list -address=https://vault_svr_url -format=yaml data/buildkite/testpipe : exit 0 " \
     "kv list -address=https://vault_svr_url -format=yaml data/buildkite : echo -e '- git-credentials'"
@@ -284,9 +242,6 @@ load "${BATS_PLUGIN_PATH}/load.bash"
 }
 
 @test "Load pipeline git-credentials from vault into GIT_CONFIG_PARAMETERS" {
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_SERVER=https://vault_svr_url
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_DUMP_ENV=true
-  export BUILDKITE_PIPELINE_SLUG=testpipe
   export TESTDATA_ENV1='MY_SECRET1=baa1'
 
   stub vault \
@@ -309,10 +264,6 @@ load "${BATS_PLUGIN_PATH}/load.bash"
 #-------
 # ssh-keys
 @test "Load default ssh-key from vault into ssh-agent" {
-  export BUILDKITE_PIPELINE_SLUG=testpipe
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_SERVER=https://vault_svr_url
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_DUMP_ENV=true
-  export BUILDKITE_PIPELINE_SLUG=testpipe
   export TESTDATA='echo foobar'
 
   stub ssh-agent "-s : echo export SSH_AGENT_PID=26345"
@@ -337,10 +288,6 @@ load "${BATS_PLUGIN_PATH}/load.bash"
 }
 
 @test "Load project ssh-key from vault into ssh-agent" {
-  export BUILDKITE_PIPELINE_SLUG=testpipe
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_SERVER=https://vault_svr_url
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_DUMP_ENV=true
-  export BUILDKITE_PIPELINE_SLUG=testpipe
   export TESTDATA='echo foobar'
 
   stub ssh-agent "-s : echo export SSH_AGENT_PID=26345"
@@ -365,10 +312,6 @@ load "${BATS_PLUGIN_PATH}/load.bash"
 }
 
 @test "Load default and project ssh-keys from vault into ssh-agent" {
-  export BUILDKITE_PIPELINE_SLUG=testpipe
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_SERVER=https://vault_svr_url
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_DUMP_ENV=true
-  export BUILDKITE_PIPELINE_SLUG=testpipe
   export TESTDATA='echo foobar'
   export TESTDATA2='echo foobar2'
 
@@ -393,15 +336,9 @@ load "${BATS_PLUGIN_PATH}/load.bash"
   unstub ssh-agent
   unstub vault
   unstub ssh-add
-
 }
-#-------
-#
+
 @test "Load default ssh-key and env from vault" {
-  export BUILDKITE_PIPELINE_SLUG=testpipe
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_SERVER=https://vault_svr_url
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_DUMP_ENV=true
-  export BUILDKITE_PIPELINE_SLUG=testpipe
   export TESTDATA_KEY='echo foobar'
   export TESTDATA_ENV='MY_SECRET=fooblah'
 
@@ -429,10 +366,6 @@ load "${BATS_PLUGIN_PATH}/load.bash"
 }
 
 @test "Load project ssh-key and env from vault" {
-  export BUILDKITE_PIPELINE_SLUG=testpipe
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_SERVER=https://vault_svr_url
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_DUMP_ENV=true
-  export BUILDKITE_PIPELINE_SLUG=testpipe
   export TESTDATA_KEY='echo foobar'
   export TESTDATA_ENV='MY_SECRET=fooblah'
 
@@ -459,13 +392,7 @@ load "${BATS_PLUGIN_PATH}/load.bash"
   unstub ssh-add
 }
 
-#-------
-#
 @test "Load default ssh-key, env and git-credentials from vault into ssh-agent" {
-  export BUILDKITE_PIPELINE_SLUG=testpipe
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_SERVER=https://vault_svr_url
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_DUMP_ENV=true
-  export BUILDKITE_PIPELINE_SLUG=testpipe
   export TESTDATA_KEY='echo foobar'
   export TESTDATA_ENV='MY_SECRET=fooblah'
   export TESTDATA_GIT='me@pass'
@@ -497,10 +424,6 @@ load "${BATS_PLUGIN_PATH}/load.bash"
 }
 
 @test "Load project ssh-key, env and git-credentials from vault into ssh-agent" {
-  export BUILDKITE_PIPELINE_SLUG=testpipe
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_SERVER=https://vault_svr_url
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_DUMP_ENV=true
-  export BUILDKITE_PIPELINE_SLUG=testpipe
   export TESTDATA_KEY='echo foobar'
   export TESTDATA_ENV='MY_SECRET=fooblah'
   export TESTDATA_GIT='me@pass'
@@ -531,10 +454,6 @@ load "${BATS_PLUGIN_PATH}/load.bash"
 }
 
 @test "Dump env secrets" {
-  export BUILDKITE_PIPELINE_SLUG=testpipe
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_SERVER=https://vault_svr_url
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_DUMP_ENV=true
-  export BUILDKITE_PIPELINE_SLUG=testpipe
   export TESTDATA_ENV_1='TEST_SECRET=foobar'
   export TESTDATA_ENV_2='ANOTHER_SECRET=foo'
 
@@ -560,10 +479,6 @@ load "${BATS_PLUGIN_PATH}/load.bash"
 
 @test "test path option" {
   export BUILDKITE_PLUGIN_VAULT_SECRETS_PATH=foobar
-  export BUILDKITE_PIPELINE_SLUG=testpipe
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_SERVER=https://vault_svr_url
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_DUMP_ENV=false
-  export BUILDKITE_PIPELINE_SLUG=testpipe
 
   stub vault \
     "kv list -address=https://vault_svr_url -format=yaml foobar/testpipe : exit 0" \
@@ -585,10 +500,7 @@ load "${BATS_PLUGIN_PATH}/load.bash"
 
 @test "Custom Namespace is set in environment hook" {
   export BUILDKITE_PLUGIN_VAULT_SECRETS_NAMESPACE=llamas
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_SERVER=https://vault_svr_url
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_DUMP_ENV=true
   export TESTDATA='MY_SECRET=fooblah'
-  export BUILDKITE_PIPELINE_SLUG=testpipe
 
   stub vault \
     "kv list -address=https://vault_svr_url -format=yaml data/buildkite/testpipe : exit 0" \

--- a/tests/examples-env-helper.bats
+++ b/tests/examples-env-helper.bats
@@ -14,29 +14,37 @@ setup() {
 
 #-------
 @test "Add environment secret var to project using example helper" {
+  EXPECTED_DATA='TVlfU0VDUkVUPSdmb29ibGFoJwo=' # MY_SECRET='fooblah'
+  INPUT_DATA=$(mktemp)
 
   stub vault \
     "token-lookup : exit 0" \
-    "write kv/buildkite/testpipe/env/MY_SECRET value=- : exit 0"
+    "write kv/buildkite/testpipe/env/MY_SECRET value=- : cat >${INPUT_DATA}"
 
   run bash -c "$PWD/examples/update-env-secret --pipeline ${BUILDKITE_PIPELINE_SLUG} --var MY_SECRET --value fooblah"
 
   assert_success
+  assert_equal "$(cat "${INPUT_DATA}")" "${EXPECTED_DATA}"
 
   unstub vault
+  rm "${INPUT_DATA}"
 }
 
 @test "Add environment secret var to project using example helper via stdin" {
+  EXPECTED_DATA='TVlfU0VDUkVUPSdmb29ibGFoJwo=' # MY_SECRET='fooblah'
+  INPUT_DATA=$(mktemp)
 
   stub vault \
     "token-lookup : exit 0" \
-    "write kv/buildkite/testpipe/env/MY_SECRET value=- : exit 0"
+    "write kv/buildkite/testpipe/env/MY_SECRET value=- : cat >${INPUT_DATA}"
 
   run bash -c "echo fooblah | $PWD/examples/update-env-secret --pipeline ${BUILDKITE_PIPELINE_SLUG} --var MY_SECRET"
 
   assert_success
+  assert_equal "$(cat "${INPUT_DATA}")" "${EXPECTED_DATA}"
 
   unstub vault
+  rm "${INPUT_DATA}"
 }
 
 @test "Adding environment secret var to default will fail using example helper" {

--- a/tests/examples-sshkey-helper.bats
+++ b/tests/examples-sshkey-helper.bats
@@ -1,9 +1,9 @@
 #!/usr/bin/env bats
 
-load '/usr/local/lib/bats/load.bash'
+load "${BATS_PLUGIN_PATH}/load.bash"
 
 # export SSH_AGENT_STUB_DEBUG=/dev/tty
-#  export SSH_KEYGEN_STUB_DEBUG=/dev/tty
+# export SSH_KEYGEN_STUB_DEBUG=/dev/tty
 # export SSH_ADD_STUB_DEBUG=/dev/tty
 # export VAULT_STUB_DEBUG=/dev/tty
 # export GIT_STUB_DEBUG=/dev/tty
@@ -12,12 +12,9 @@ load '/usr/local/lib/bats/load.bash'
 @test "Add sshkey secret var to project using example helper" {
   export VAULT_ADDR=https://vault_svr_url
   export BUILDKITE_PIPELINE_SLUG=testpipe
-  export TESTDATA=`echo MY_SECRET=fooblah | base64`
 
   stub ssh-keygen \
-    "-f ./private_ssh_key -N * : touch private_ssh_key ; touch private_ssh_key.pub"
-  # Due to the anonyances of escaping variables etc ...
-  # ssh-keygen is actually run with -N '', but that doesn't play nice with the stub so we ignore it
+    "-f \* -N '' : touch \$2 ; touch \$2.pub"
 
   stub vault \
     "token-lookup : exit 0" \

--- a/tests/git-credentials.bats
+++ b/tests/git-credentials.bats
@@ -1,26 +1,30 @@
 #!/usr/bin/env bats
 
-load "${BATS_PLUGIN_PATH}/load.bash"
-
 # export SSH_AGENT_STUB_DEBUG=/dev/tty
 # export SSH_ADD_STUB_DEBUG=/dev/tty
 # export VAULT_STUB_DEBUG=/dev/tty
 # export GIT_STUB_DEBUG=/dev/tty
 
+setup() {
+  load "${BATS_PLUGIN_PATH}/load.bash"
 
-# Schema for git-crednetials Secrets
+  export BUILDKITE_PIPELINE_SLUG=testpipe
+
+  export BUILDKITE_PLUGIN_VAULT_SECRETS_ADDR=https://vault_svr_url
+
+  export GIT_CONFIG_PARAMETERS="'credential.helper=basedir/git-credential-vault-secrets ${BUILDKITE_PLUGIN_VAULT_SECRETS_ADDR} data/buildkite/testpipe/git-credentials'"
+}
+
+# Schema for git-credentials Secrets
 # [schema://][user[:password]@]host[:port][/path][?[arg1=val1]...][#fragment]
 
-@test "Get basic git-credentials from vault server" {
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_ADDR=https://vault_svr_url
-  export BUILDKITE_PIPELINE_SLUG=testpipe
-  export GIT_CONFIG_PARAMETERS="'credential.helper=basedir/git-credential-vault-secrets ${BUILDKITE_PLUGIN_VAULT_SECRETS_ADDR} data/buildkite/testpipe/git-credentials'"
-  export TESTDATA="https://user:password@host.io:7999/path"
+@test "Basic url" {
+  export TESTDATA="https://user:password@host.io"
 
   stub vault \
     "kv get -address=https://vault_svr_url -field=data -format=yaml data/buildkite/testpipe/git-credentials : echo ${TESTDATA}"
 
-  run ./git-credential-vault-secrets ${BUILDKITE_PLUGIN_VAULT_SECRETS_ADDR} data/buildkite/${BUILDKITE_PIPELINE_SLUG}/git-credentials
+  run ./git-credential-vault-secrets "${BUILDKITE_PLUGIN_VAULT_SECRETS_ADDR}" "data/buildkite/${BUILDKITE_PIPELINE_SLUG}/git-credentials"
 
   assert_success
   assert_output --partial "protocol=https"
@@ -29,26 +33,15 @@ load "${BATS_PLUGIN_PATH}/load.bash"
   assert_output --partial "password=password"
 
   unstub vault
-
-  unset TESTDATA
-  unset TEST_CREDS1
-  unset GIT_CONFIG_PARAMETERS
-  unset BUILDKITE_PLUGIN_VAULT_SECRETS_ADDR
-  unset BUILDKITE_PIPELINE_SLUG
 }
 
-@test "Get git-credentials with args from vault server" {
-  skip "creds with args are not parsing correctly"
-  export BUILDKITE_PLUGIN_VAULT_SECRETS_ADDR=https://vault_svr_url
-  export BUILDKITE_PIPELINE_SLUG=testpipe
-  export GIT_CONFIG_PARAMETERS="'credential.helper=basedir/git-credential-vault-secrets ${BUILDKITE_PLUGIN_VAULT_SECRETS_ADDR} data/buildkite/testpipe/git-credentials'"
-  # [schema://][user[:password]@]host[:port][/path][?[arg1=val1]...][#fragment]
-  export TESTDATA='https://user:password@host.io:7999/path?arg1=val1'
+@test "URL with args" {
+  export TESTDATA='https://user:password@host.io/?arg1=val1'
 
   stub vault \
-    "read -address=https://vault_svr_url -field=value data/buildkite/testpipe/git-credentials : echo ${TESTDATA}"
+    "kv get -address=https://vault_svr_url -field=data -format=yaml data/buildkite/testpipe/git-credentials : echo ${TESTDATA}"
 
-  run ./git-credential-vault-secrets ${BUILDKITE_PLUGIN_VAULT_SECRETS_ADDR} data/buildkite/${BUILDKITE_PIPELINE_SLUG}/git-credentials
+  run ./git-credential-vault-secrets "${BUILDKITE_PLUGIN_VAULT_SECRETS_ADDR}" "data/buildkite/${BUILDKITE_PIPELINE_SLUG}/git-credentials"
 
   assert_success
   assert_output --partial "protocol=https"
@@ -57,10 +50,91 @@ load "${BATS_PLUGIN_PATH}/load.bash"
   assert_output --partial "password=password"
 
   unstub vault
+}
 
-  unset TESTDATA
-  unset TEST_CREDS1
-  unset GIT_CONFIG_PARAMETERS
-  unset BUILDKITE_PLUGIN_VAULT_SECRETS_ADDR
-  unset BUILDKITE_PIPELINE_SLUG
+@test "URL with multiple args" {
+  export TESTDATA='https://user:password@host.io/?arg1=val1&arg2=val2'
+
+  stub vault \
+    "kv get -address=https://vault_svr_url -field=data -format=yaml data/buildkite/testpipe/git-credentials : echo ${TESTDATA}"
+
+  run ./git-credential-vault-secrets "${BUILDKITE_PLUGIN_VAULT_SECRETS_ADDR}" "data/buildkite/${BUILDKITE_PIPELINE_SLUG}/git-credentials"
+
+  assert_success
+  assert_output --partial "protocol=https"
+  assert_output --partial "host=host.io"
+  assert_output --partial "username=user"
+  assert_output --partial "password=password"
+
+  unstub vault
+}
+
+@test "URL with fragment" {
+  export TESTDATA='https://user:password@host.io/#anchor'
+
+  stub vault \
+    "kv get -address=https://vault_svr_url -field=data -format=yaml data/buildkite/testpipe/git-credentials : echo ${TESTDATA}"
+
+  run ./git-credential-vault-secrets "${BUILDKITE_PLUGIN_VAULT_SECRETS_ADDR}" "data/buildkite/${BUILDKITE_PIPELINE_SLUG}/git-credentials"
+
+  assert_success
+  assert_output --partial "protocol=https"
+  assert_output --partial "host=host.io"
+  assert_output --partial "username=user"
+  assert_output --partial "password=password"
+
+  unstub vault
+}
+
+@test "URL with path" {
+  export TESTDATA='https://user:password@host.io/path'
+
+  stub vault \
+    "kv get -address=https://vault_svr_url -field=data -format=yaml data/buildkite/testpipe/git-credentials : echo ${TESTDATA}"
+
+  run ./git-credential-vault-secrets "${BUILDKITE_PLUGIN_VAULT_SECRETS_ADDR}" "data/buildkite/${BUILDKITE_PIPELINE_SLUG}/git-credentials"
+
+  assert_success
+  assert_output --partial "protocol=https"
+  assert_output --partial "host=host.io"
+  assert_output --partial "username=user"
+  assert_output --partial "password=password"
+
+  unstub vault
+}
+
+@test "URL with port" {
+  # [schema://][user[:password]@]host[:port][/path][?[arg1=val1]...][#fragment]
+  export TESTDATA='https://user:password@host.io:7999/'
+
+  stub vault \
+    "kv get -address=https://vault_svr_url -field=data -format=yaml data/buildkite/testpipe/git-credentials : echo ${TESTDATA}"
+
+  run ./git-credential-vault-secrets "${BUILDKITE_PLUGIN_VAULT_SECRETS_ADDR}" "data/buildkite/${BUILDKITE_PIPELINE_SLUG}/git-credentials"
+
+  assert_success
+  assert_output --partial "protocol=https"
+  assert_output --partial "host=host.io:7999"
+  assert_output --partial "username=user"
+  assert_output --partial "password=password"
+
+  unstub vault
+}
+
+@test "URL with everything" {
+  # [schema://][user[:password]@]host[:port][/path][?[arg1=val1]...][#fragment]
+  export TESTDATA='https://user:password@host.io:7999/path?arg=val&arg2=val2#anchor'
+
+  stub vault \
+    "kv get -address=https://vault_svr_url -field=data -format=yaml data/buildkite/testpipe/git-credentials : echo ${TESTDATA}"
+
+  run ./git-credential-vault-secrets "${BUILDKITE_PLUGIN_VAULT_SECRETS_ADDR}" "data/buildkite/${BUILDKITE_PIPELINE_SLUG}/git-credentials"
+
+  assert_success
+  assert_output --partial "protocol=https"
+  assert_output --partial "host=host.io:7999"
+  assert_output --partial "username=user"
+  assert_output --partial "password=password"
+
+  unstub vault
 }

--- a/tests/git-credentials.bats
+++ b/tests/git-credentials.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-load '/usr/local/lib/bats/load.bash'
+load "${BATS_PLUGIN_PATH}/load.bash"
 
 # export SSH_AGENT_STUB_DEBUG=/dev/tty
 # export SSH_ADD_STUB_DEBUG=/dev/tty

--- a/tests/git-credentials.bats
+++ b/tests/git-credentials.bats
@@ -15,8 +15,7 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_VAULT_SECRETS_ADDR=https://vault_svr_url
   export BUILDKITE_PIPELINE_SLUG=testpipe
   export GIT_CONFIG_PARAMETERS="'credential.helper=basedir/git-credential-vault-secrets ${BUILDKITE_PLUGIN_VAULT_SECRETS_ADDR} data/buildkite/testpipe/git-credentials'"
-  export TEST_CREDS1="https://user:password@host.io:7999/path"
-  export TESTDATA=`echo -n "${TEST_CREDS1}"`
+  export TESTDATA="https://user:password@host.io:7999/path"
 
   stub vault \
     "kv get -address=https://vault_svr_url -field=data -format=yaml data/buildkite/testpipe/git-credentials : echo ${TESTDATA}"
@@ -43,9 +42,8 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_VAULT_SECRETS_ADDR=https://vault_svr_url
   export BUILDKITE_PIPELINE_SLUG=testpipe
   export GIT_CONFIG_PARAMETERS="'credential.helper=basedir/git-credential-vault-secrets ${BUILDKITE_PLUGIN_VAULT_SECRETS_ADDR} data/buildkite/testpipe/git-credentials'"
-  export TEST_CREDS1='https://user:password@host.io:7999/path?arg1=val1'
   # [schema://][user[:password]@]host[:port][/path][?[arg1=val1]...][#fragment]
-  export TESTDATA=`echo -n "${TEST_CREDS1}" | base64`
+  export TESTDATA='https://user:password@host.io:7999/path?arg1=val1'
 
   stub vault \
     "read -address=https://vault_svr_url -field=value data/buildkite/testpipe/git-credentials : echo ${TESTDATA}"


### PR DESCRIPTION
* deactivated the dependency dashboard (closes #6)
* uses plugin tester instead of docker compose in pipeline
* refactor and clean-up in tests
  - `unset` calls are no longer necessary
  - moved common variables to all tests to `setup` function
  - use tester variable to load extensions
  - fixed all test data format (should have been YAML-like)
* shellcheck warnings and errors
  - corrected them all in all scripts in repository
  - added all scripts in repository to shellcheck plugin paths
* big fixes in `git-credential-vault-secrets`
  - output now includes port in the `host` entry (as [per spec](https://git-scm.com/docs/git-credential#Documentation/git-credential.txt-codehostcode))
  - when parsing finishes, function does not fail (which prevented tests with arguments)
* added a lot of tests to `git-credential-vault-secrets`
