### PR TITLE
Update environment hook with default namespace as root instead of admin

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -79,7 +79,7 @@ else
 fi
 
 # Check to see if we are using a different namespace for cloud/enterprise, otherwise use the default
-export VAULT_NAMESPACE="${BUILDKITE_PLUGIN_VAULT_SECRETS_NAMESPACE:-admin}"
+export VAULT_NAMESPACE="${BUILDKITE_PLUGIN_VAULT_SECRETS_NAMESPACE:-root}"
 echo "Using namespace: $VAULT_NAMESPACE"
 
 vault_server="${BUILDKITE_PLUGIN_VAULT_SECRETS_SERVER:-}"


### PR DESCRIPTION
This PR updates the default namespace from admin to root. This will be a breaking change for customers who are already using plugin with admin as it's default namespace but as per the documentation of vault the top level namespace is root so making that as default namespace is correct thing to do or else customers who do not use namespace will always have to set namespace value as root in the plugin config.