### PR TITLE
Update openssh package as unable to find previous version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ FROM vault:1.13.3
 # vault doesn't include bash by default, and we want some functionality that bash provides
 # so we'll install it manually and pin the version
 # Install openssh so that we can run sshkey intgeration tests
-RUN apk add bash=5.2.15-r5 openssh=9.3_p2-r0
+RUN apk add bash=5.2.15-r5 openssh=9.3_p2-r1


### PR DESCRIPTION
`openssh=9.3_p2-r0` is no longer available and therefore the Container image cannot successfully build resulting in failing tests.