### PR TITLE
Fix integration tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,7 +7,7 @@ steps:
       queue: "hosted"
     plugins:
       - shellcheck#v1.3.0:
-          files: 
+          files:
             - lib/*.bash
             - hooks/*
             - .buildkite/*.sh
@@ -24,13 +24,13 @@ steps:
       queue: "hosted"
     plugins:
       - plugin-tester#v1.1.1: ~
-          
+
   - label: ":vault: :test_tube: Integration Tests"
     command: .buildkite/steps/test_integration.sh
     agents:
       queue: "hosted"
     plugins:
-      docker-compose#v5.2.0:
+      docker-compose#v5.3.0:
         config:
           - docker-compose-integration.yml
         run: vault-tester

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ FROM vault:1.13.3
 # vault doesn't include bash by default, and we want some functionality that bash provides
 # so we'll install it manually and pin the version
 # Install openssh so that we can run sshkey intgeration tests
-RUN apk add bash=5.2.15-r5 openssh=9.3_p2-r1
+RUN apk add bash=5.2.15-r5 openssh=9.3_p2-r2

--- a/hooks/environment
+++ b/hooks/environment
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-set -o xtrace
 set -eu -o pipefail
 
 processSshSecrets() {

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -53,14 +53,12 @@ vault_auth() {
         return "${PIPESTATUS[0]}"
       ;;
 
-    # AWS Authentication  
+    # AWS Authentication
     aws)
         # set the role name to use; either from the plugin configuration, or fall back to the EC2 instance role
         if [ -z "${BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_AWS_ROLE_NAME:-}" ]; then
-          # Check to see if we are running on EC2
-          RUNNING_ON_EC2=$(aws_platform_check)
           # get the name of the IAM role the EC2 instance is using, if any
-          EC2_INSTANCE_IAM_ROLE=$( [ "$RUNNING_ON_EC2" = true ]; curl http://169.254.169.254/latest/meta-data/iam/security-credentials)
+          EC2_INSTANCE_IAM_ROLE=$(curl http://169.254.169.254/latest/meta-data/iam/security-credentials)
           aws_role_name="${EC2_INSTANCE_IAM_ROLE}"
         else
           aws_role_name="${BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_AWS_ROLE_NAME}"
@@ -221,22 +219,4 @@ add_ssh_private_key_to_agent() {
 
 grep_secrets() {
   grep -E 'private_ssh_key|id_rsa_github|env|environment|git-credentials$' "$@"
-}
-
-
-aws_platform_check() {
-    if [ -f /sys/hypervisor/uuid ]; then
-      if [ "$(head -c 3 /sys/hypervisor/uuid)" == "ec2" ]; then
-        return 0
-      else
-        return 1
-      fi
-
-    elif [ -r /sys/devices/virtual/dmi/id/product_uuid ]; then
-      if [ "$(head -c 3 /sys/devices/virtual/dmi/id/product_uuid)" == "EC2" ]; then
-        return 0
-      else
-        return 1
-      fi
-    fi
 }

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -185,7 +185,7 @@ secret_download() {
     ' <<< "$_secret" | jq -r '
         [paths(scalars) as $p |
             {key: $p | join("_"), value: getpath($p)}
-        ] | .[] | "\(.key)=\(.value)"
+        ] | .[] | "\(.key)=\"\(.value)\""
     ')
   fi
 

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -15,15 +15,15 @@ vault_auth() {
   #   The plugin will reference these two values for the RoleID and SecretID:
   #     BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_SECRET_ENV (default: $VAULT_SECRET_ID)
   #     BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_ROLE_ID
-  
+
   ##  AWS Authentication
   #   AWS auth method only requires you to pass the name of a valid Vault role in your login call, which is not
   #   sensitive information itself, so the role name to use can either be passed via BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_AWS_ROLE_NAME
-  #   or will fall back to using the name of the IAM role that the instance is using. 
+  #   or will fall back to using the name of the IAM role that the instance is using.
 
 
   case "${BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_METHOD:-}" in
-    
+
     # AppRole authentication
     approle)
         if [ -z "${BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_SECRET_ENV:-}" ]; then
@@ -36,7 +36,7 @@ vault_auth() {
           echo "+++  🚨 No vault secret id found"
           exit 1
         fi
-        
+
         # export the vault token to be used for this job - this command writes to the auth/approle/login endpoint
         # on success, vault will return the token which we export as VAULT_TOKEN for this shell
         if ! VAULT_TOKEN=$(vault write -field=token -address="$server" auth/approle/login \
@@ -71,7 +71,7 @@ vault_auth() {
           exit 1
         fi
 
-        # export the vault token to be used for this job - this is a standard vault auth command 
+        # export the vault token to be used for this job - this is a standard vault auth command
         # on success, vault will return the token which we export as VAULT_TOKEN for this shell
         if ! VAULT_TOKEN=$(vault login -field=token -address="$server" -method=aws role="$aws_role_name"); then
           echo "+++🚨 Failed to get vault token"
@@ -109,7 +109,6 @@ vault_auth() {
         return "${PIPESTATUS[0]}"
     ;;
   esac
-  
 }
 
 list_secrets() {
@@ -156,7 +155,7 @@ secret_download() {
   local key="$2"
 
   # Attempt to retrieve the secret from Vault
-if ! _secret=$(vault kv get -address="$server" -field=data -format=yaml "$key" | \
+  if ! _secret=$(vault kv get -address="$server" -field=data -format=yaml "$key" | \
     sed -r '
         s/: /=/;       # Replace ':' with '='
         s/\"/\\"/g;    # Escape double quotes
@@ -167,30 +166,30 @@ if ! _secret=$(vault kv get -address="$server" -field=data -format=yaml "$key" |
     # If the command fails, print an error message and exit
     echo "Failed to download secrets: $_secret"
     exit 1
-fi
+  fi
 
   # Check if the first character of the _secret variable is a '{'
-if [[ "${_secret:0:1}" == "{" ]]; then
+  if [[ "${_secret:0:1}" == "{" ]]; then
     # It's JSON, handle accordingly
 
     # Retrieve the secret from Vault, extract the 'data' field, and format it as JSON
-    _secret=$(vault kv get -address="$server" -field=data -format=json "$key" | sed -r 's/: /=/; s/\"/\\"/g;')
+    _secret=$(vault kv get -address="$server" -field=data -format=json "$key")
 
     # Process the JSON secret to replace underscores and periods in keys
     _secret=$(jq -c '
         walk(
-            if type == "object" then 
-                with_entries(.key |= gsub("_"; "__") | gsub("\\."; "_")) 
-            else 
-                . 
+            if type == "object" then
+                with_entries(.key |= gsub("[^A-Za-z0-9_]"; "_"))
+            else
+                .
             end
         )
     ' <<< "$_secret" | jq -r '
-        [paths(scalars) as $p | 
+        [paths(scalars) as $p |
             {key: $p | join("_"), value: getpath($p)}
         ] | .[] | "\(.key)=\(.value)"
     ')
-fi
+  fi
 
   echo "$_secret"
 }

--- a/tests/auth-tests.bats
+++ b/tests/auth-tests.bats
@@ -8,7 +8,10 @@ load "${BATS_PLUGIN_PATH}/load.bash"
 # export CURL_STUB_DEBUG=/dev/tty
 # export GIT_STUB_DEBUG=/dev/tty
 
-CURL_DEFAULT_STUB='\* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \*'
+setup() {
+  # if this is not defined, the hook will try to use EC2 metadata to get the instance role
+  export BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_AWS_ROLE_NAME='role'
+}
 
 @test "approle auth method" {
   export BUILDKITE_PLUGIN_VAULT_SECRETS_PATH=foobar
@@ -25,7 +28,7 @@ CURL_DEFAULT_STUB='\* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \
     "kv list -address=https://vault_svr_url -format=yaml foobar : exit 0"
 
   run bash -c "$PWD/hooks/environment && $PWD/hooks/pre-exit"
-  
+
   assert_success
   assert_output --partial 'Successfully authenticated with RoleID'
 
@@ -41,7 +44,7 @@ CURL_DEFAULT_STUB='\* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \
   export BUILDKITE_PIPELINE_SLUG=testpipe
 
   stub vault \
-    "login -field=token -address=https://vault_svr_url -method=aws role="llamas" : echo 'Successfully authenticated with IAM Role ${5}'"\
+    "login -field=token -address=https://vault_svr_url -method=aws role=\"llamas\" : echo 'Successfully authenticated with IAM Role ${5}'"\
     "kv list -address=https://vault_svr_url -format=yaml foobar/testpipe : exit 0" \
     "kv list -address=https://vault_svr_url -format=yaml foobar : exit 0"
 
@@ -60,13 +63,16 @@ CURL_DEFAULT_STUB='\* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \
   export BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_METHOD=aws
   export BUILDKITE_PIPELINE_SLUG=testpipe
 
+  # force check
+  unset BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_AWS_ROLE_NAME
+
   stub vault \
-    "login -field=token -address=https://vault_svr_url -method=aws role="llamas" : echo 'Successfully authenticated with IAM Role ${5}'"\
+    "login -field=token -address=https://vault_svr_url -method=aws role=\"llamas\" : echo 'Successfully authenticated with IAM Role ${5}'"\
     "kv list -address=https://vault_svr_url -format=yaml foobar/testpipe : exit 0" \
     "kv list -address=https://vault_svr_url -format=yaml foobar : exit 0"
 
   stub curl \
-    "${CURL_DEFAULT_STUB} : echo llamas"
+    "\* : echo llamas"
 
   run bash -c "$PWD/hooks/environment && $PWD/hooks/pre-exit"
 
@@ -86,7 +92,7 @@ CURL_DEFAULT_STUB='\* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \
   export BUILDKITE_PIPELINE_SLUG=testpipe
 
   stub vault \
-    "write auth/jwt/login -address="https://vault_svr_url" jwt=llamas : echo 'Successfully authenticated.'"\
+    "write auth/jwt/login -address=\"https://vault_svr_url\" jwt=llamas : echo 'Successfully authenticated.'"\
     "kv list -address=https://vault_svr_url -format=yaml foobar/testpipe : exit 0" \
     "kv list -address=https://vault_svr_url -format=yaml foobar : exit 0"
 
@@ -107,7 +113,7 @@ CURL_DEFAULT_STUB='\* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \
   export BUILDKITE_PIPELINE_SLUG=testpipe
 
   stub vault \
-    "write auth/jwt/login -address="https://vault_svr_url" jwt=llamas : echo 'Successfully authenticated.'"\
+    "write auth/jwt/login -address=\"https://vault_svr_url\" jwt=llamas : echo 'Successfully authenticated.'"\
     "kv list -address=https://vault_svr_url -format=yaml foobar/testpipe : exit 0" \
     "kv list -address=https://vault_svr_url -format=yaml foobar : exit 0"
 
@@ -129,7 +135,7 @@ CURL_DEFAULT_STUB='\* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \
   export BUILDKITE_PIPELINE_SLUG=testpipe
 
   stub vault \
-    "write auth/jwt/login -address="https://vault_svr_url" jwt=llamas : echo 'Successfully authenticated.'"\
+    "write auth/jwt/login -address=\"https://vault_svr_url\" jwt=llamas : echo 'Successfully authenticated.'"\
     "kv list -address=https://vault_svr_url -format=yaml foobar/testpipe : exit 0" \
     "kv list -address=https://vault_svr_url -format=yaml foobar : exit 0"
 

--- a/tests/environment-hook.bats
+++ b/tests/environment-hook.bats
@@ -264,12 +264,6 @@ setup() {
 #-------
 # ssh-keys
 @test "Load default ssh-key from vault into ssh-agent" {
-
-  export SSH_AGENT_STUB_DEBUG=/dev/tty
-  export SSH_ADD_STUB_DEBUG=/dev/tty
-  export VAULT_STUB_DEBUG=/dev/tty
-  export GIT_STUB_DEBUG=/dev/tty
-
   export TESTDATA='foobar'
 
   stub ssh-agent "-s : echo export SSH_AGENT_PID=26345"
@@ -558,7 +552,7 @@ setup() {
     "kv list -address=https://vault_svr_url -format=yaml data/buildkite : echo '${BUILDKITE_PLUGIN_VAULT_SECRETS_SECRET}'" \
     "kv get -address=https://vault_svr_url -field=data -format=yaml data/buildkite/testpipe/${BUILDKITE_PLUGIN_VAULT_SECRETS_SECRET} : echo ${TESTDATA}" \
     "kv get -address=https://vault_svr_url -field=data -format=yaml data/buildkite/${BUILDKITE_PLUGIN_VAULT_SECRETS_SECRET} : echo ${TESTDATA2}"
-    
+
 
   run bash -c "$PWD/hooks/environment && $PWD/hooks/pre-exit"
 
@@ -573,7 +567,7 @@ setup() {
 
 @test "Load env, environment, and custom secret key files for project and default from vault server" {
   export BUILDKITE_PLUGIN_VAULT_SECRETS_SECRET="supersecret"
-  
+
   export TESTDATA_ENV1='MY_SECRET1: baa1'
   export TESTDATA_ENV2='MY_SECRET2: baa2'
   export TESTDATA_ENV3='MY_SECRET3: baa3'

--- a/tests/environment-hook.bats
+++ b/tests/environment-hook.bats
@@ -604,8 +604,8 @@ setup() {
   stub vault \
     "kv list -address=https://vault_svr_url -format=yaml data/buildkite/testpipe : exit 0" \
     "kv list -address=https://vault_svr_url -format=yaml data/buildkite : echo 'env'" \
-    "kv get -address=https://vault_svr_url -field=data -format=yaml data/buildkite/env : echo ${TESTDATA}" \
-    "kv get -address=https://vault_svr_url -field=data -format=json data/buildkite/env : echo ${TESTDATA}"
+    "kv get -address=https://vault_svr_url -field=data -format=yaml data/buildkite/env : echo '${TESTDATA}'" \
+    "kv get -address=https://vault_svr_url -field=data -format=json data/buildkite/env : echo '${TESTDATA}'"
 
   run bash -c "$PWD/hooks/environment && $PWD/hooks/pre-exit"
 

--- a/tests/environment-hook.bats
+++ b/tests/environment-hook.bats
@@ -599,7 +599,7 @@ setup() {
 }
 
 @test "Load custom json secret" {
-  export TESTDATA='{"MY_SECRET": "fooblah"}'
+  export TESTDATA='{"MY_SECRET": "fooblah", "OTHER SECRET": "foo bar"}'
 
   stub vault \
     "kv list -address=https://vault_svr_url -format=yaml data/buildkite/testpipe : exit 0" \
@@ -611,7 +611,9 @@ setup() {
 
   assert_success
   assert_output --partial "MY_SECRET=fooblah"
-  refute_output --partial "ANOTHER_SECRET=baa"
+  assert_output --partial "OTHER_SECRET=foo bar"
+  refute_output --partial "OTHER SECRET=foobar"
+  refute_output --partial "OTHER_SECRET=foobar"
 
   unstub vault
 }


### PR DESCRIPTION
4 changes:

* update `openssh` package version to install to avoid integration test failure
* update docker-compose plugin version to latest one (same as #55)
* remove code path that did some very low-level checks to ensure it was running in AWS only to hit the metadata endpoint that broke running tests in any non-AWS environment
* remove `xtrace` bash option that means it will print out way too much information (possibly including sensitive information)

The latter surfaced a test that has been failing since it was incorporated in #51 . I tried to make it better up to the limits of my understanding of what the original intention was and corrected a bug on values with spaces.