### PR TITLE
fix: JWT auth method 

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,10 @@ The environment variable which holds the **secret-id** used to authenticate to V
 
 The environment variable which contains the **JSON Web Token** used to authenticate to Vault. Defaults to `VAULT_JWT`
 
+#### `jwt-role` (optional, string)
+
+The role name that should be used to log in to Vault. Defaults to `buildkite`
+
 Example:
 
 ```yaml

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -95,7 +95,7 @@ vault_auth() {
           exit 1
         fi
 
-        if ! VAULT_TOKEN=$(vault write auth/jwt/login -address="$server"  jwt="${jwt_var:-}"); then
+        if ! VAULT_TOKEN=$(vault write -field=token auth/jwt/login role="${BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_JWT_ROLE:-"buildkite"}" jwt="${jwt_var:-}"); then
           echo "+++🚨 Failed to get vault token"
           exit 1
         fi

--- a/plugin.yml
+++ b/plugin.yml
@@ -33,6 +33,8 @@ configuration:
           type: string
         jwt-env:
           type: string
+        jwt-role:
+          type: string
     secrets:
       type: array
   additionalProperties: false

--- a/tests/auth-tests.bats
+++ b/tests/auth-tests.bats
@@ -92,7 +92,7 @@ setup() {
   export BUILDKITE_PIPELINE_SLUG=testpipe
 
   stub vault \
-    "write auth/jwt/login -address=\"https://vault_svr_url\" jwt=llamas : echo 'Successfully authenticated.'"\
+    "write -field=token auth/jwt/login role=buildkite jwt=llamas : echo 'Successfully authenticated.'"\
     "kv list -address=https://vault_svr_url -format=yaml foobar/testpipe : exit 0" \
     "kv list -address=https://vault_svr_url -format=yaml foobar : exit 0"
 
@@ -104,7 +104,7 @@ setup() {
   unstub vault
 }
 
-@test "auth using jwt with default jwt var" {
+@test "auth using jwt with default jwt values" {
   export BUILDKITE_PLUGIN_VAULT_SECRETS_PATH=foobar
   export BUILDKITE_PLUGIN_VAULT_SECRETS_SERVER=https://vault_svr_url
   export BUILDKITE_PLUGIN_VAULT_SECRETS_DUMP_ENV=false
@@ -113,7 +113,7 @@ setup() {
   export BUILDKITE_PIPELINE_SLUG=testpipe
 
   stub vault \
-    "write auth/jwt/login -address=\"https://vault_svr_url\" jwt=llamas : echo 'Successfully authenticated.'"\
+    "write -field=token auth/jwt/login role=buildkite jwt=llamas : echo 'Successfully authenticated.'"\
     "kv list -address=https://vault_svr_url -format=yaml foobar/testpipe : exit 0" \
     "kv list -address=https://vault_svr_url -format=yaml foobar : exit 0"
 
@@ -135,7 +135,30 @@ setup() {
   export BUILDKITE_PIPELINE_SLUG=testpipe
 
   stub vault \
-    "write auth/jwt/login -address=\"https://vault_svr_url\" jwt=llamas : echo 'Successfully authenticated.'"\
+    "write -field=token auth/jwt/login role=buildkite jwt=llamas : echo 'Successfully authenticated.'"\
+    "kv list -address=https://vault_svr_url -format=yaml foobar/testpipe : exit 0" \
+    "kv list -address=https://vault_svr_url -format=yaml foobar : exit 0"
+
+  run bash -c "$PWD/hooks/environment && $PWD/hooks/pre-exit"
+
+  assert_success
+  assert_output --partial 'Successfully authenticated with JWT'
+
+  unstub vault
+}
+
+@test "auth using jwt with role and jwt_var set" {
+  export BUILDKITE_PLUGIN_VAULT_SECRETS_PATH=foobar
+  export BUILDKITE_PLUGIN_VAULT_SECRETS_SERVER=https://vault_svr_url
+  export BUILDKITE_PLUGIN_VAULT_SECRETS_DUMP_ENV=false
+  export BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_METHOD=jwt
+  export BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_JWT_ENV=VERY_COOL
+  export BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_JWT_ROLE="bkbkbk"
+  export VERY_COOL=llamas
+  export BUILDKITE_PIPELINE_SLUG=testpipe
+
+  stub vault \
+    "write -field=token auth/jwt/login role=bkbkbk jwt=llamas : echo 'Successfully authenticated.'"\
     "kv list -address=https://vault_svr_url -format=yaml foobar/testpipe : exit 0" \
     "kv list -address=https://vault_svr_url -format=yaml foobar : exit 0"
 


### PR DESCRIPTION
### Description
I noticed that JWT auth wasn't working as expecting when attempting to configure it in my environment, then discovered that it probably hasn't ever been working; the `vault write` command used and the handling of the token was completely incorrect, so this aims to fix that and introduce some sensible defaults (such as a `role` to use when authenticating).

I've tested this locally and it works, and added some tests into `auth-tests` to cover most configurations.

### What's changing
* update README with new options
* update tests
* adds a new attribute `jwt-role` 
* JWT auth method now properly receives a token from the vault after successfully authenticating