### PR TITLE
Target the ephemeral ssh-agent PID created when loading secrets

### DIFF
--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-if [[ -n "${SSH_AGENT_PID:-}" ]] && ps -p "$SSH_AGENT_PID" &>/dev/null; then
-  echo "~~~ Stopping ssh-agent ${SSH_AGENT_PID}"
-  ssh-agent -k
+if [[ -n "${EPHEMERAL_SSH_AGENT_PID:-}" ]] && ps -p "$EPHEMERAL_SSH_AGENT_PID" &>/dev/null; then
+  echo "~~~ Stopping ssh-agent ${EPHEMERAL_SSH_AGENT_PID}"
+  SSH_AGENT_PID="${EPHEMERAL_SSH_AGENT_PID}" ssh-agent -k
+else
+  echo "~~~ No Ephemeral SSH Agent found"
 fi

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -210,6 +210,7 @@ add_ssh_private_key_to_agent() {
   if [[ -z "${SSH_AGENT_PID:-}" ]] ; then
     echo "Starting an ephemeral ssh-agent" >&2;
     eval "$(ssh-agent -s)"
+    export EPHEMERAL_SSH_AGENT_PID="${SSH_AGENT_PID}"
   fi
 
   echo "Loading ssh-key into ssh-agent (pid ${SSH_AGENT_PID:-})" >&2;


### PR DESCRIPTION
Captures the SSH_AGENT_PID of the ephemeral ssh-agent process which is created when loading ssh keys from vault, and ignores pre-existing ssh-agent PIDs.

This is intended to prevent the plugin's `pre-exit` hook from arbitrarily stopping an ssh-agent that is already running on the agent instance.