### PR TITLE
Use `kill -0` to replace `ps -p` in `pre-exit` hook

### DIFF
--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ -n "${EPHEMERAL_SSH_AGENT_PID:-}" ]] && ps -p "$EPHEMERAL_SSH_AGENT_PID" &>/dev/null; then
+if [[ -n "${EPHEMERAL_SSH_AGENT_PID:-}" ]] && kill -0 "$EPHEMERAL_SSH_AGENT_PID" 2>/dev/null; then
   echo "~~~ Stopping ssh-agent ${EPHEMERAL_SSH_AGENT_PID}"
   SSH_AGENT_PID="${EPHEMERAL_SSH_AGENT_PID}" ssh-agent -k
 else


### PR DESCRIPTION
Previous check:
`ps -p "$EPHEMERAL_SSH_AGENT_PID" &>/dev/null`

Revised check:
`kill -0 "$EPHEMERAL_SSH_AGENT_PID" 2>/dev/null`

Using `ps` requires reading from `/proc` filesystem to enumerate all processes, which can be an exhaustive list that relies on fast filesystem I/O. This generates alot of syscalls for each process. Systems under high load can cause this approach to be delayed.

Switch to using `kill -0` sends signal 0 (`null`) to the process, allowing the kernel to perform a direct lookup in the process table and return immediately with exit code `0` (success) or `1` (not found). This is a single syscall and doesn't require any parsing of the process table.

Fixes https://github.com/buildkite-plugins/vault-secrets-buildkite-plugin/issues/74