### PR TITLE
Get secret output from KV secrets as JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,15 @@ Defaults to: `data/buildkite`
 ### `namespace` (optional, string)
 Configure the [Enterprise Namespace](https://developer.hashicorp.com/vault/docs/enterprise/namespaces) to be used when querying the vault server
 
+### `output` (optional, string)
+Select the output format used by the Vault CLI when getting secrets from Vault. 
+Expects one of the following values:
+
+* `yaml`
+* `json`
+
+Default: `yaml`
+
 ### `debug` (optional, boolean)
 Enable detailed debug logging to troubleshoot connection and authentication issues with Vault.
 

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -185,7 +185,7 @@ secret_download() {
     ' <<< "$_secret" | jq -r '
         [paths(scalars) as $p |
             {key: $p | join("_"), value: getpath($p)}
-        ] | .[] | "\(.key)=\"\(.value)\""
+        ] | .[] | "\(.key)=\(.value | @sh)"
     ' 2>&1); then
       echo "Failed to parse JSON secret from $key" >&2
       echo "JSON parse error: $_secret" >&2
@@ -237,7 +237,7 @@ secret_download() {
       ' <<< "$_secret" | jq -r '
           [paths(scalars) as $p |
               {key: $p | join("_"), value: getpath($p)}
-          ] | .[] | "\(.key)=\"\(.value)\""
+          ] | .[] | "\(.key)=\(.value | @sh)"
       ' 2>&1); then
         echo "Failed to parse JSON secret from $key" >&2
         echo "JSON parse error: $_secret" >&2

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -21,90 +21,89 @@ vault_auth() {
   #   sensitive information itself, so the role name to use can either be passed via BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_AWS_ROLE_NAME
   #   or will fall back to using the name of the IAM role that the instance is using.
 
-
   case "${BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_METHOD:-}" in
 
-    # AppRole authentication
-    approle)
-        if [ -z "${BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_SECRET_ENV:-}" ]; then
-          secret_var="${VAULT_SECRET_ID?No Secret ID found}"
-        else
-          secret_var="${!BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_SECRET_ENV}"
-        fi
+  # AppRole authentication
+  approle)
+    if [ -z "${BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_SECRET_ENV:-}" ]; then
+      secret_var="${VAULT_SECRET_ID?No Secret ID found}"
+    else
+      secret_var="${!BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_SECRET_ENV}"
+    fi
 
-        if [[ -z "${secret_var:-}" ]]; then
-          echo "+++  🚨 No vault secret id found"
-          exit 1
-        fi
+    if [[ -z "${secret_var:-}" ]]; then
+      echo "+++  🚨 No vault secret id found"
+      exit 1
+    fi
 
-        # export the vault token to be used for this job - this command writes to the auth/approle/login endpoint
-        # on success, vault will return the token which we export as VAULT_TOKEN for this shell
-        if ! VAULT_TOKEN=$(vault write -field=token -address="$server" auth/approle/login \
-        role_id="$BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_ROLE_ID" \
-        secret_id="${secret_var:-}"); then
-          echo "+++🚨 Failed to get vault token"
-          exit 1
-        fi
+    # export the vault token to be used for this job - this command writes to the auth/approle/login endpoint
+    # on success, vault will return the token which we export as VAULT_TOKEN for this shell
+    if ! VAULT_TOKEN=$(vault write -field=token -address="$server" auth/approle/login \
+      role_id="$BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_ROLE_ID" \
+      secret_id="${secret_var:-}"); then
+      echo "+++🚨 Failed to get vault token"
+      exit 1
+    fi
 
-        export VAULT_TOKEN
+    export VAULT_TOKEN
 
-        echo "Successfully authenticated with RoleID ${BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_ROLE_ID} and updated vault token"
+    echo "Successfully authenticated with RoleID ${BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_ROLE_ID} and updated vault token"
 
-        return "${PIPESTATUS[0]}"
-      ;;
+    return "${PIPESTATUS[0]}"
+    ;;
 
-    # AWS Authentication
-    aws)
-        # set the role name to use; either from the plugin configuration, or fall back to the EC2 instance role
-        if [ -z "${BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_AWS_ROLE_NAME:-}" ]; then
-          # get the name of the IAM role the EC2 instance is using, if any
-          EC2_INSTANCE_IAM_ROLE=$(curl http://169.254.169.254/latest/meta-data/iam/security-credentials)
-          aws_role_name="${EC2_INSTANCE_IAM_ROLE}"
-        else
-          aws_role_name="${BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_AWS_ROLE_NAME}"
-        fi
+  # AWS Authentication
+  aws)
+    # set the role name to use; either from the plugin configuration, or fall back to the EC2 instance role
+    if [ -z "${BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_AWS_ROLE_NAME:-}" ]; then
+      # get the name of the IAM role the EC2 instance is using, if any
+      EC2_INSTANCE_IAM_ROLE=$(curl http://169.254.169.254/latest/meta-data/iam/security-credentials)
+      aws_role_name="${EC2_INSTANCE_IAM_ROLE}"
+    else
+      aws_role_name="${BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_AWS_ROLE_NAME}"
+    fi
 
-        if [[ -z "${aws_role_name:-}" ]]; then
-          echo "+++🚨 No EC2 instance IAM role defined; value is $aws_role_name"
-          exit 1
-        fi
+    if [[ -z "${aws_role_name:-}" ]]; then
+      echo "+++🚨 No EC2 instance IAM role defined; value is $aws_role_name"
+      exit 1
+    fi
 
-        # export the vault token to be used for this job - this is a standard vault auth command
-        # on success, vault will return the token which we export as VAULT_TOKEN for this shell
-        if ! VAULT_TOKEN=$(vault login -field=token -address="$server" -method=aws role="$aws_role_name"); then
-          echo "+++🚨 Failed to get vault token"
-        fi
+    # export the vault token to be used for this job - this is a standard vault auth command
+    # on success, vault will return the token which we export as VAULT_TOKEN for this shell
+    if ! VAULT_TOKEN=$(vault login -field=token -address="$server" -method=aws role="$aws_role_name"); then
+      echo "+++🚨 Failed to get vault token"
+    fi
 
-        export VAULT_TOKEN
+    export VAULT_TOKEN
 
-        echo "Successfully authenticated with IAM Role ${aws_role_name} and updated vault token"
+    echo "Successfully authenticated with IAM Role ${aws_role_name} and updated vault token"
 
-        return "${PIPESTATUS[0]}"
-      ;;
+    return "${PIPESTATUS[0]}"
+    ;;
 
-    jwt)
-        echo "--- performing JWT authentication"
-        if [ -z "${BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_JWT_ENV:-}" ]; then
-          jwt_var="${VAULT_JWT?No JWT found}"
-        else
-          jwt_var="${!BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_JWT_ENV}"
-        fi
+  jwt)
+    echo "--- performing JWT authentication"
+    if [ -z "${BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_JWT_ENV:-}" ]; then
+      jwt_var="${VAULT_JWT?No JWT found}"
+    else
+      jwt_var="${!BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_JWT_ENV}"
+    fi
 
-        if [[ -z "${jwt_var:-}" ]]; then
-          echo "+++  🚨 No JWT found."
-          exit 1
-        fi
+    if [[ -z "${jwt_var:-}" ]]; then
+      echo "+++  🚨 No JWT found."
+      exit 1
+    fi
 
-        if ! VAULT_TOKEN=$(vault write -field=token auth/jwt/login role="${BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_JWT_ROLE:-"buildkite"}" jwt="${jwt_var:-}"); then
-          echo "+++🚨 Failed to get vault token"
-          exit 1
-        fi
+    if ! VAULT_TOKEN=$(vault write -field=token auth/jwt/login role="${BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_JWT_ROLE:-"buildkite"}" jwt="${jwt_var:-}"); then
+      echo "+++🚨 Failed to get vault token"
+      exit 1
+    fi
 
-        export VAULT_TOKEN
+    export VAULT_TOKEN
 
-        echo "Successfully authenticated with JWT"
+    echo "Successfully authenticated with JWT"
 
-        return "${PIPESTATUS[0]}"
+    return "${PIPESTATUS[0]}"
     ;;
   esac
 }
@@ -116,12 +115,12 @@ list_secrets() {
   local _list
 
   if ! _list=$(vault kv list -address="$server" -format=yaml "$key" 2>&1 | sed 's/^- //g'); then
-    echo "unable to list secrets at $key: $_list" >&2;
+    echo "unable to list secrets at $key: $_list" >&2
     return 1
   fi
   local retVal=${PIPESTATUS[0]}
 
-  for lineItem in ${_list} ; do
+  for lineItem in ${_list}; do
     echo "$key/${lineItem}"
   done
 
@@ -137,11 +136,11 @@ secret_exists() {
   local _key_name
   _key_name="$(basename "$key")"
   local _list
-  _list=$(vault kv list -address="$server" -format=yaml "$_key_base" )
+  _list=$(vault kv list -address="$server" -format=yaml "$_key_base")
 
-  echo "${_list}" | grep "^- ${_key_name}$" >& /dev/null
+  echo "${_list}" | grep "^- ${_key_name}$" >&/dev/null
   # shellcheck disable=SC2181
-  if [ "$?" -ne 0 ] ; then
+  if [ "$?" -ne 0 ]; then
     return 1
   else
     return 0
@@ -151,40 +150,28 @@ secret_exists() {
 secret_download() {
   local server="$1"
   local key="$2"
+  # should default to YAML, but allows the option for getting JSON output.
+  local output="${BUILDKITE_PLUGIN_VAULT_SECRETS_OUTPUT:-"yaml"}"
 
   # Attempt to retrieve the secret from Vault with detailed error capture
   local vault_error
-  if ! _secret=$(vault kv get -address="$server" -field=data -format=yaml "$key" 2>&1 | \
-    sed -r '
-        s/: /=/;       # Replace ':' with '='
-        s/\"/\\"/g;    # Escape double quotes
-        s/\$/\\$/g;    # Escape dollar signs
-        s/=(.*)$/="\1"/g; # Enclose values in double quotes
-    '); then
 
-    # Capture the vault command error for better debugging
-    vault_error=$(vault kv get -address="$server" -field=data -format=yaml "$key" 2>&1)
-    echo "Failed to download secret from $key" >&2
-    echo "Vault error: $vault_error" >&2
+  if [[ "${output}" == "json" ]]; then
+    # JSON output - no sed transformation needed
+    if ! _secret=$(vault kv get -address="$server" -field=data -format=json "$key" 2>&1); then
+      vault_error=$_secret
+      echo "Failed to download secret from $key" >&2
+      echo "Vault error: $vault_error" >&2
 
-    # Additional context for common errors
-    if [[ "$vault_error" =~ "EOF" ]]; then
-      echo "EOF error often indicates network connectivity issues or server problems" >&2
-    elif [[ "$vault_error" =~ "permission denied" ]]; then
-      echo "Permission denied - check if the token has access to this secret path" >&2
-    elif [[ "$vault_error" =~ "path not found" ]]; then
-      echo "Secret path not found - verify the path exists in Vault" >&2
+      if [[ "$vault_error" =~ "EOF" ]]; then
+        echo "EOF error often indicates network connectivity issues or server problems" >&2
+      elif [[ "$vault_error" =~ "permission denied" ]]; then
+        echo "Permission denied - check if the token has access to this secret path" >&2
+      elif [[ "$vault_error" =~ "path not found" ]]; then
+        echo "Secret path not found - verify the path exists in Vault" >&2
+      fi
+      exit 1
     fi
-
-    exit 1
-  fi
-
-  # Check if the first character of the _secret variable is a '{'
-  if [[ "${_secret:0:1}" == "{" ]]; then
-    # It's JSON, handle accordingly
-
-    # Retrieve the secret from Vault, extract the 'data' field, and format it as JSON
-    _secret=$(vault kv get -address="$server" -field=data -format=json "$key")
 
     # Process the JSON secret to replace underscores and periods in keys
     _secret=$(jq -c '
@@ -200,6 +187,55 @@ secret_download() {
             {key: $p | join("_"), value: getpath($p)}
         ] | .[] | "\(.key)=\"\(.value)\""
     ')
+  else
+    # YAML output - apply sed transformation
+    if ! _secret=$(vault kv get -address="$server" -field=data -format=yaml "$key" 2>&1 | \
+      sed -r '
+          s/: /=/;       # Replace ':' with '='
+          s/\"/\\"/g;    # Escape double quotes
+          s/\$/\\$/g;    # Escape dollar signs
+          s/=(.*)$/="\1"/g; # Enclose values in double quotes
+      '); then
+
+      # Capture the vault command error for better debugging
+      vault_error=$(vault kv get -address="$server" -field=data -format=yaml "$key" 2>&1)
+      echo "Failed to download secret from $key" >&2
+      echo "Vault error: $vault_error" >&2
+
+      # Additional context for common errors
+      if [[ "$vault_error" =~ "EOF" ]]; then
+        echo "EOF error often indicates network connectivity issues or server problems" >&2
+      elif [[ "$vault_error" =~ "permission denied" ]]; then
+        echo "Permission denied - check if the token has access to this secret path" >&2
+      elif [[ "$vault_error" =~ "path not found" ]]; then
+        echo "Secret path not found - verify the path exists in Vault" >&2
+      fi
+
+      exit 1
+    fi
+
+    # Check if the first character of the _secret variable is a '{'
+    if [[ "${_secret:0:1}" == "{" ]]; then
+      # The YAML output contains JSON, handle accordingly
+
+      # Retrieve the secret from Vault as JSON format instead
+      _secret=$(vault kv get -address="$server" -field=data -format=json "$key")
+
+      # Process the JSON secret to replace underscores and periods in keys
+      _secret=$(jq -c '
+          walk(
+              if type == "object" then
+                  with_entries(.key |= gsub("[^A-Za-z0-9_]"; "_"))
+              else
+                  .
+              end
+          )
+      ' <<< "$_secret" | jq -r '
+          [paths(scalars) as $p |
+              {key: $p | join("_"), value: getpath($p)}
+          ] | .[] | "\(.key)=\"\(.value)\""
+      ')
+    fi
   fi
 
   echo "$_secret"
@@ -220,13 +256,13 @@ ssh_key_download() {
 add_ssh_private_key_to_agent() {
   local ssh_key="$1"
 
-  if [[ -z "${SSH_AGENT_PID:-}" ]] ; then
-    echo "Starting an ephemeral ssh-agent" >&2;
+  if [[ -z "${SSH_AGENT_PID:-}" ]]; then
+    echo "Starting an ephemeral ssh-agent" >&2
     eval "$(ssh-agent -s)"
     export EPHEMERAL_SSH_AGENT_PID="${SSH_AGENT_PID}"
   fi
 
-  echo "Loading ssh-key into ssh-agent (pid ${SSH_AGENT_PID:-})" >&2;
+  echo "Loading ssh-key into ssh-agent (pid ${SSH_AGENT_PID:-})" >&2
 
   echo "$ssh_key" | env SSH_ASKPASS="/bin/false" ssh-add -
 }

--- a/plugin.yml
+++ b/plugin.yml
@@ -16,6 +16,10 @@ configuration:
       type: string
     namespace:
       type: string
+    output:
+      enum:
+        - 'yaml'
+        - 'json'
     debug:
       type: boolean
       description: "Enable detailed debug logging to troubleshoot Vault connection issues"

--- a/tests/environment-hook.bats
+++ b/tests/environment-hook.bats
@@ -86,6 +86,21 @@ setup() {
   unstub vault
 }
 
+@test "Load default env file with a multi-line secret with JSON output from vault server" {
+  export BUILDKITE_PLUGIN_VAULT_SECRETS_OUTPUT="json"
+  export TESTDATA='{"license": "\"something or other \\\n  comment\" another=\"more \\\n  info\" date=\"2020482983\" \\\n  end=\"finished\""}'
+
+  stub vault \
+    "kv list -address=https://vault_svr_url -format=yaml data/buildkite/testpipe : exit 0" \
+    "kv list -address=https://vault_svr_url -format=yaml data/buildkite : echo 'env'" \
+    "kv get -address=https://vault_svr_url -field=data -format=json data/buildkite/env : echo '${TESTDATA}'"
+
+  run bash -c "$PWD/hooks/environment && $PWD/hooks/pre-exit"
+
+  assert_success
+  unstub vault
+}
+
 @test "Load default environment file from vault server" {
   export TESTDATA='MY_SECRET: fooblah'
 


### PR DESCRIPTION
This PR aims to provide a workaround for a bit of an edge case, specifically for multi-line secrets that would be cutoff when using the existing command: `vault kv get -address="$server" -field=data -format=yaml "$key"`.

To work around this, we can use the JSON output option of the `vault kv get` command,  and `jq` to parse the value while maintaining line breaks and other formatting. To do this, we can use `-format=json` instead of `yaml`. 

In order to prevent this from being a breaking change, also adds a new option in the plugin config - `output`, which accepts `yaml` or `json`, and defaults to `yaml` if no option is set.

```yaml
steps:
 - command: ...
   plugins:
        - vault-secrets#v2.4.0:
              server: "http://vault-svr:8200"
              path: secret/buildkite/some-path
              output: json
              auth:
                method: "approle"
                role-id: "${VAULT_ROLE_ID}
```


Tests pass locally, and the change has been validated against vault with a secret that is shaped like this:
```shell
secret='"something or other \
  comment" another="more \
  info" date="2020482983" \
  end="finished"'
```