### PR TITLE
Fix secret leak on vault CLI failures

### DIFF
--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -165,7 +165,7 @@ process_json_to_shell_vars() {
       [paths(scalars) as $p |
           {key: $p | join("_"), value: getpath($p)}
       ] | .[] | "\(.key)=\(.value | @sh)"
-  ' 2>&1
+  '
 }
 
 secret_download() {
@@ -174,13 +174,23 @@ secret_download() {
   # should default to YAML, but allows the option for getting JSON output.
   local output="${BUILDKITE_PLUGIN_VAULT_SECRETS_OUTPUT:-"yaml"}"
 
-  # Attempt to retrieve the secret from Vault with detailed error capture
+  # Attempt to retrieve the secret from Vault with detailed error capture.
+  # IMPORTANT: `vault kv get` writes the secret to stdout. Never echo captured
+  # stdout in an error path - only Vault's stderr is safe to surface, otherwise
+  # secret material (e.g. partially streamed before a mid-transfer EOF/5xx) would
+  # leak into the build log.
   local vault_error
+  local _vault_stderr
+  _vault_stderr=$(mktemp)
+  # secret_download is always invoked inside a command substitution subshell, so
+  # an EXIT trap reliably cleans up the temp file on every path (success, the
+  # several `exit 1` error paths, or an interrupt) without scattering `rm -f`.
+  trap 'rm -f "$_vault_stderr"' EXIT
 
   if [[ "${output}" == "json" ]]; then
     # JSON output - no sed transformation needed
-    if ! _secret=$(vault kv get -address="$server" -field=data -format=json "$key" 2>&1); then
-      vault_error=$_secret
+    if ! _secret=$(vault kv get -address="$server" -field=data -format=json "$key" 2>"$_vault_stderr"); then
+      vault_error=$(cat "$_vault_stderr")
       echo "Failed to download secret from $key" >&2
       echo "Vault error: $vault_error" >&2
 
@@ -194,15 +204,20 @@ secret_download() {
       exit 1
     fi
 
-    # Process the JSON secret to replace underscores and periods in keys
-    if ! _secret=$(process_json_to_shell_vars "$_secret"); then
+    # Process the JSON secret to replace underscores and periods in keys.
+    # jq's stderr is routed to the temp file (not surfaced) because parse errors
+    # can echo fragments of the input - i.e. the secret - so neither the captured
+    # output nor jq's diagnostics are safe to print.
+    if ! _secret=$(process_json_to_shell_vars "$_secret" 2>"$_vault_stderr"); then
       echo "Failed to parse JSON secret from $key" >&2
-      echo "JSON parse error: $_secret" >&2
+      echo "JSON parse error: details suppressed to avoid leaking secret material" >&2
       exit 1
     fi
   else
-    # YAML output - apply sed transformation
-    if ! _secret=$(vault kv get -address="$server" -field=data -format=yaml "$key" 2>&1 | \
+    # YAML output - apply sed transformation. Vault's stderr is redirected to a
+    # file (not merged into the piped stdout) so a failure never feeds secret
+    # bytes through sed, and so the error handler can surface stderr only.
+    if ! _secret=$(vault kv get -address="$server" -field=data -format=yaml "$key" 2>"$_vault_stderr" | \
       sed -r '
           s/: /=/;       # Replace ':' with '='
           s/\"/\\"/g;    # Escape double quotes
@@ -210,8 +225,8 @@ secret_download() {
           s/=(.*)$/="\1"/g; # Enclose values in double quotes
       '); then
 
-      # Capture the vault command error for better debugging
-      vault_error=$(vault kv get -address="$server" -field=data -format=yaml "$key" 2>&1)
+      # Surface only Vault's stderr - never the captured stdout, which holds the secret.
+      vault_error=$(cat "$_vault_stderr")
       echo "Failed to download secret from $key" >&2
       echo "Vault error: $vault_error" >&2
 
@@ -231,13 +246,20 @@ secret_download() {
     if [[ "${_secret:0:1}" == "{" ]]; then
       # The YAML output contains JSON, handle accordingly
 
-      # Retrieve the secret from Vault as JSON format instead
-      _secret=$(vault kv get -address="$server" -field=data -format=json "$key")
+      # Retrieve the secret from Vault as JSON format instead. Same hardening as
+      # the download paths above: isolate Vault's stderr and check for failure so
+      # a mid-transfer error can never feed secret bytes into the error handler.
+      if ! _secret=$(vault kv get -address="$server" -field=data -format=json "$key" 2>"$_vault_stderr"); then
+        vault_error=$(cat "$_vault_stderr")
+        echo "Failed to download secret from $key" >&2
+        echo "Vault error: $vault_error" >&2
+        exit 1
+      fi
 
       # Process the JSON secret to replace underscores and periods in keys
-      if ! _secret=$(process_json_to_shell_vars "$_secret"); then
+      if ! _secret=$(process_json_to_shell_vars "$_secret" 2>"$_vault_stderr"); then
         echo "Failed to parse JSON secret from $key" >&2
-        echo "JSON parse error: $_secret" >&2
+        echo "JSON parse error: details suppressed to avoid leaking secret material" >&2
         exit 1
       fi
     fi

--- a/tests/secret-leak-on-failure.bats
+++ b/tests/secret-leak-on-failure.bats
@@ -1,0 +1,88 @@
+#!/usr/bin/env bats
+
+# These tests guard against secret material being echoed to the build log when a
+# `vault kv get` call fails. Vault writes the secret to *stdout*; if that stdout
+# is captured (e.g. via `2>&1`) and then printed as part of an error message, the
+# secret leaks. This happens in practice when a request fails mid-transfer
+# (EOF / connection reset / 5xx) after Vault has already streamed secret bytes.
+
+setup() {
+  load "${BATS_PLUGIN_PATH}/load.bash"
+
+  # Source the library under test so we can call secret_download directly.
+  source "${PWD}/lib/shared.bash"
+
+  export BUILDKITE_PLUGIN_VAULT_SECRETS_SERVER=https://vault_svr_url
+}
+
+# export VAULT_STUB_DEBUG=/dev/tty
+
+@test "yaml output: secret is not leaked when vault fails mid-transfer" {
+  unset BUILDKITE_PLUGIN_VAULT_SECRETS_OUTPUT  # defaults to yaml
+
+  # vault streams the secret to stdout, then drops the connection (EOF) and exits non-zero.
+  stub vault \
+    "kv get -address=https://vault_svr_url -field=data -format=yaml secret/leaky : echo 'MY_SECRET: hunter2-leaked-value'; echo 'Error making API request. Code: 500. Errors: EOF' >&2; exit 1"
+
+  run secret_download "https://vault_svr_url" "secret/leaky"
+
+  assert_failure
+  # We still want a useful, non-secret error message...
+  assert_output --partial "Failed to download secret from secret/leaky"
+  # ...but the secret value must never appear in the output.
+  refute_output --partial "hunter2-leaked-value"
+
+  unstub vault
+}
+
+@test "json output: secret is not leaked when vault fails mid-transfer" {
+  export BUILDKITE_PLUGIN_VAULT_SECRETS_OUTPUT=json
+
+  stub vault \
+    "kv get -address=https://vault_svr_url -field=data -format=json secret/leaky : echo '{\"MY_SECRET\":\"hunter2-leaked-value\"}'; echo 'Error making API request. Code: 500. Errors: EOF' >&2; exit 1"
+
+  run secret_download "https://vault_svr_url" "secret/leaky"
+
+  assert_failure
+  assert_output --partial "Failed to download secret from secret/leaky"
+  refute_output --partial "hunter2-leaked-value"
+
+  unstub vault
+}
+
+@test "yaml output: secret is not leaked when the JSON re-fetch fails mid-transfer" {
+  unset BUILDKITE_PLUGIN_VAULT_SECRETS_OUTPUT  # defaults to yaml
+
+  # When the (sed-processed) YAML output starts with '{', secret_download re-fetches
+  # the secret as JSON. That second call must be hardened just like the first: if it
+  # streams secret bytes and then fails, none of it may reach the build log.
+  stub vault \
+    "kv get -address=https://vault_svr_url -field=data -format=yaml secret/jsonish : echo '{\"foo\": \"bar\"}'" \
+    "kv get -address=https://vault_svr_url -field=data -format=json secret/jsonish : echo 'refetch-leaked-value'; echo 'Error making API request. Code: 500. Errors: EOF' >&2; exit 1"
+
+  run secret_download "https://vault_svr_url" "secret/jsonish"
+
+  assert_failure
+  assert_output --partial "Failed to download secret from secret/jsonish"
+  refute_output --partial "refetch-leaked-value"
+
+  unstub vault
+}
+
+@test "json output: secret is not leaked when JSON parsing fails" {
+  export BUILDKITE_PLUGIN_VAULT_SECRETS_OUTPUT=json
+
+  # Download succeeds but returns content jq cannot parse. jq's diagnostics can echo
+  # fragments of its input (the secret), so the parse-error path must not surface
+  # either the captured output or jq's stderr.
+  stub vault \
+    "kv get -address=https://vault_svr_url -field=data -format=json secret/badjson : echo 'not-valid-json-leaked-value'"
+
+  run secret_download "https://vault_svr_url" "secret/badjson"
+
+  assert_failure
+  assert_output --partial "Failed to parse JSON secret from secret/badjson"
+  refute_output --partial "not-valid-json-leaked-value"
+
+  unstub vault
+}


### PR DESCRIPTION
## Summary

  `vault kv get` writes secret material to **stdout**. Several error paths in
  `secret_download` captured that stdout and then printed it as part of an error
  message, leaking secrets into the build log. This happens in practice when a
  request fails **mid-transfer** (EOF / connection reset / 5xx) after Vault has
  already streamed secret bytes, or when the returned payload fails to parse.

  This PR ensures that on any failure, only Vault's **stderr** (which carries the
  error, not the secret) can reach the build log.

  ## Changes

  - **Download paths** redirect Vault's stderr to a temp file rather than merging
    it into stdout with `2>&1`, and surface only that stderr on failure. For the
    YAML path this also means a failure never feeds secret bytes through `sed`.
  - **YAML→JSON re-fetch** (the branch that re-queries Vault as JSON when YAML
    output begins with `{`) is now hardened identically — previously it ran a bare
    `vault kv get` with no stderr isolation and no failure check.
  - **JSON parse errors** no longer echo the captured value or jq's diagnostics.
    jq can include fragments of its input (the secret) in error messages, so
    `process_json_to_shell_vars` drops its trailing `2>&1` and callers route jq's
    stderr to the temp file, emitting a generic "details suppressed" message. This
    also closes a pre-existing leak where the first jq stage's stderr went
  straight
    to the log.
  - **Cleanup** of the stderr temp file is handled by a single `EXIT` trap
  covering
    every path (success, the `exit 1` branches, and interrupts).

  ## Tests

  Added `tests/secret-leak-on-failure.bats` (4 cases): YAML and JSON mid-transfer
  download failures, the JSON re-fetch failure, and the JSON parse-error path.
  Each
  asserts a useful non-secret error is shown **and** that the secret value never
  appears in the output.

  - All 62 tests pass (`buildkite/plugin-tester`)
  - `shellcheck` clean

  ## Out of scope

  `list_secrets` still uses `2>&1` and echoes its output on error, but it surfaces
  secret *key names* rather than values — a different, much lower sensitivity
  class.
  Left unchanged deliberately

## Disclosures/Credits
Code changes authored with Claude Opus 4.8