### PR TITLE
fix: resolve _vault_stderr unbound variable in EXIT trap

### DIFF
--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -185,6 +185,9 @@ secret_download() {
   # secret_download is always invoked inside a command substitution subshell, so
   # an EXIT trap reliably cleans up the temp file on every path (success, the
   # several `exit 1` error paths, or an interrupt) without scattering `rm -f`.
+  # Intentional early expansion: capture the literal path now before the local variable
+  # goes out of scope when the function returns.
+  # shellcheck disable=SC2064
   trap "rm -f $_vault_stderr" EXIT
 
   if [[ "${output}" == "json" ]]; then

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -185,7 +185,7 @@ secret_download() {
   # secret_download is always invoked inside a command substitution subshell, so
   # an EXIT trap reliably cleans up the temp file on every path (success, the
   # several `exit 1` error paths, or an interrupt) without scattering `rm -f`.
-  trap 'rm -f "$_vault_stderr"' EXIT
+  trap "rm -f $_vault_stderr" EXIT
 
   if [[ "${output}" == "json" ]]; then
     # JSON output - no sed transformation needed


### PR DESCRIPTION
  trap used single quotes so  was evaluated at fire time, after the local variable had gone out of scope. Adding double quotes so that it expands at set time, baking the literal path into the trap string.